### PR TITLE
feat: add production-grade native WebSocket keepalive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added correlated native WebSocket keepalive for Tokio and Compio, including
+  plain/compressed unified streams, split streams, Axum, and generic
+  TCP/TLS/HTTP transport wrappers.
+- Added `Config::{pong_timeout,pong_timeout_close_code,
+  pong_timeout_close_reason,close_timeout}` and their builder methods.
+- Added typed `Error::HeartbeatTimeout` and `Error::IdleTimeout` causes.
+- Added deterministic heartbeat state-machine, Tokio split-driver, Axum
+  plain/permessage-deflate, masking, Close, and Compio control-driver tests.
+
+### Changed
+
+- `ping_interval` is now an inbound-inactivity interval rather than a fixed
+  cadence. One nonce-bearing Ping may be outstanding; only its exact Pong
+  clears the deadline.
+- `idle_timeout` now implements its documented hard inbound-idle deadline.
+  `Config::uws_defaults()` disables that independent deadline so it cannot
+  close before its first keepalive Ping.
+- Split writers are bounded command handles. A connection-scoped driver owns
+  the transport writer and prioritizes automatic Pong, Close, and heartbeat
+  traffic even when the application performs no writes.
+- Split readers expose Ping and Pong messages after automatic protocol work.
+
+### Compatibility
+
+- Existing builder-based configuration and `split()` call sites keep the same
+  method-level API. Tokio split transports must now be `Send + 'static`
+  because the writer driver is connection-scoped Tokio work.
+- Adding public `Config` fields is source-breaking for downstream exhaustive
+  struct literals; use `Config::builder()` or `..Config::default()`. Adding
+  typed public `Error` variants is source-breaking for exhaustive matches.
+  These changes are intentional so timeout causes are not collapsed into EOF.
+
 ## [2.0.0] - 2026-07-24
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,6 +2102,7 @@ dependencies = [
  "dashmap",
  "fastrand",
  "flate2",
+ "futures-channel",
  "futures-core",
  "futures-sink",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,12 @@ tokio-runtime = [
     "dep:tokio-util",
     "tokio-util/codec",
 ]
-compio-runtime = ["dep:compio", "compio/polling"]
+compio-runtime = [
+    "dep:compio",
+    "compio/polling",
+    "dep:futures-channel",
+    "dep:futures-util",
+]
 
 # Framework integrations
 axum-integration = ["axum", "hyper", "hyper-util", "tokio-runtime"]
@@ -124,7 +129,7 @@ tokio = { version = "^1.48", default-features = false, optional = true }
 tokio-util = { version = "^0.7", default-features = false, optional = true }
 
 # Compio completion-based async runtime
-compio = { version = "^0.18", default-features = false, features = ["net", "macros", "bytes", "sync"], optional = true }
+compio = { version = "^0.18", default-features = false, features = ["net", "macros", "bytes", "sync", "time"], optional = true }
 
 # Fast synchronization primitives for pub/sub
 parking_lot = "^0.12"
@@ -164,6 +169,8 @@ pin-project-lite = "^0.2"
 # Futures traits
 futures-core = "^0.3"
 futures-sink = "^0.3"
+futures-channel = { version = "^0.3", features = ["sink"], optional = true }
+futures-util = { version = "^0.3", default-features = false, features = ["async-await", "sink"], optional = true }
 
 # Compression (permessage-deflate, RFC 7692)
 flate2 = { version = "^1.0", default-features = false, features = ["zlib-rs"], optional = true }
@@ -209,7 +216,7 @@ tokio-uring = { version = "^0.5", optional = true }
 [dev-dependencies]
 criterion = "^0.5"
 rand = "^0.9"
-tokio = { version = "^1.48", features = ["full"] }
+tokio = { version = "^1.48", features = ["full", "test-util"] }
 tokio-tungstenite = "^0.26"
 tokio-websockets = { version = "^0.10", features = ["client", "server", "sha1_smol", "fastrand"] }
 futures-util = "^0.3"

--- a/README.md
+++ b/README.md
@@ -689,7 +689,11 @@ use sockudo_ws::{Config, Compression};
 let config = Config::builder()
     .compression(Compression::Shared)      // SHARED_COMPRESSOR
     .max_payload_length(16 * 1024)         // 16KB max message
-    .idle_timeout(10)                      // 10 second timeout
+    .ping_interval(30)                     // Ping after 30s inbound inactivity
+    .pong_timeout(10)                      // Matching Pong deadline
+    .pong_timeout_close(4201, "Pong reply not received in time")
+    .idle_timeout(0)                       // Independent hard idle limit disabled
+    .close_timeout(5)                      // Bounded Close flush/shutdown
     .max_backpressure(1024 * 1024)         // 1MB backpressure limit
     .build();
 
@@ -722,11 +726,37 @@ let config = Config::builder()
 | `compression` | `Disabled` | Compression mode |
 | `max_message_size` | 64MB | Maximum message size |
 | `max_frame_size` | 16MB | Maximum single frame size |
-| `idle_timeout` | 120s | Close connection after inactivity (0 = disabled) |
+| `idle_timeout` | 120s | Hard inbound-idle deadline, independent of Pong detection (0 = disabled) |
 | `max_backpressure` | 1MB | Max write buffer before dropping connection |
-| `auto_ping` | true | Automatic ping/pong keepalive |
-| `ping_interval` | 30s | Seconds between pings |
+| `auto_ping` | true | Enable proactive native Ping; automatic Pong/Close responses remain enabled when false |
+| `ping_interval` | 30s | Inbound inactivity before one native Ping (0 = disabled) |
+| `pong_timeout` | 10s | Matching Pong deadline after Ping flush (0 = no deadline and no second Ping until a match) |
+| `pong_timeout_close_code` | 1001 | Close code for a missed Pong |
+| `pong_timeout_close_reason` | `Pong reply not received in time` | Close reason for a missed Pong |
+| `close_timeout` | 5s | Bound for timeout Close flush and transport shutdown |
 | `write_buffer_size` | 16KB | Cork buffer size |
+
+### Native keepalive semantics
+
+Keepalive is driven by valid inbound activity, not a fixed cadence. After
+`ping_interval` with no inbound frame, sockudo-ws writes one RFC 6455 Ping with
+an opaque 8-byte nonce. The Pong timer begins only after that Ping is written
+and flushed. Only a Pong with the exact payload clears it; unsolicited, stale,
+late, or wrong-payload Pongs do not.
+
+Any valid non-Pong inbound frame resets inactivity, including while a Ping is
+outstanding, but it does not extend or satisfy that Ping's Pong deadline. If a
+hard `idle_timeout` and Pong deadline tie, the more specific Pong timeout wins,
+so only one Close and one typed terminal error are produced.
+
+On timeout, the server rejects further application data, attempts one
+configured Close within `close_timeout`, and completes local cleanup even when
+the peer is unreachable. Code 4201 can be observed on a writable path, but no
+implementation can guarantee delivery through an already-dead TCP path.
+
+These semantics are shared by Tokio and Compio, plain and
+permessage-deflate, unified and split APIs. Generic TCP/TLS and HTTP/2/HTTP/3
+streams inherit the state machine from their runtime WebSocket stream.
 
 ### Compression Modes
 
@@ -876,25 +906,27 @@ For concurrent read/write operations with zero mutex contention:
 ```rust
 let (reader, writer) = ws.split();
 
-// SplitReader - operates independently, never blocks writer
+// SplitReader - owns decoding and reports shared terminal state
 reader.next().await  // Receive message
 reader.is_closed()   // Check if closed (non-blocking)
 
-// SplitWriter - operates independently, never blocks reader
+// SplitWriter - bounded command handle to the connection writer driver
 writer.send(msg).await?;
 writer.send_text("hello").await?;
 writer.send_binary(bytes).await?;
 writer.close(1000, "bye").await?;
 writer.is_closed()   // Check if closed (non-blocking)
-writer.flush().await?;  // Flush pending control responses
+writer.flush().await?;  // Flush accepted application writes
 ```
 
 **Implementation Details:**
 - Uses `tokio::io::split()` for OS-level stream splitting
 - Reader owns `ReadHalf<S>` and protocol decoder
-- Writer owns `WriteHalf<S>` and protocol encoder
-- Control frames (Ping/Pong/Close) coordinated via mpsc channel
-- No shared mutex - true concurrent I/O
+- One connection-scoped driver exclusively owns `WriteHalf<S>` and the encoder
+- Bounded control/application queues provide backpressure under Ping floods
+- Pong and Close responses progress without later application `send()`/`flush()`
+- Dropping either half cancels the driver; EOF/Close/timeout propagates to both
+- No lock is held across an await
 
 ### Message Types
 

--- a/examples/axum_echo.rs
+++ b/examples/axum_echo.rs
@@ -77,7 +77,11 @@ where
     // Create sockudo-ws WebSocketStream with our config
     let config = Config::builder()
         .max_payload_length(16 * 1024)
-        .idle_timeout(60)
+        .ping_interval(30)
+        .pong_timeout(10)
+        .pong_timeout_close(4201, "Pong reply not received in time")
+        .idle_timeout(0)
+        .close_timeout(5)
         .build();
 
     let mut ws = WebSocketStream::server(stream, config);

--- a/src/axum_integration.rs
+++ b/src/axum_integration.rs
@@ -704,6 +704,189 @@ mod tests {
         fn _takes_split_writer(_: crate::SplitWriter<UpgradedStream>) {}
     }
 
+    fn heartbeat_test_config() -> Config {
+        Config::builder()
+            .ping_interval(1)
+            .pong_timeout(1)
+            .idle_timeout(0)
+            .close_timeout(1)
+            .pong_timeout_close(4201, "Pong reply not received in time")
+            .build()
+    }
+
+    #[derive(Default)]
+    struct HeartbeatTestState {
+        pong_seen: tokio::sync::Notify,
+    }
+
+    async fn plain_heartbeat_handler(
+        axum::extract::State(state): axum::extract::State<std::sync::Arc<HeartbeatTestState>>,
+        upgrade: WebSocketUpgrade,
+    ) -> impl IntoResponse {
+        upgrade
+            .config(heartbeat_test_config())
+            .on_upgrade(move |socket| async move {
+                let (mut reader, _writer) = socket.split();
+                while let Some(message) = reader.next().await {
+                    if matches!(message, Ok(Message::Pong(_))) {
+                        state.pong_seen.notify_one();
+                    }
+                }
+            })
+    }
+
+    #[cfg(feature = "permessage-deflate")]
+    async fn compressed_heartbeat_handler(
+        axum::extract::State(state): axum::extract::State<std::sync::Arc<HeartbeatTestState>>,
+        upgrade: WebSocketUpgrade,
+    ) -> impl IntoResponse {
+        let config = Config::builder()
+            .ping_interval(1)
+            .pong_timeout(1)
+            .idle_timeout(0)
+            .close_timeout(1)
+            .pong_timeout_close(4201, "Pong reply not received in time")
+            .enable_deflate()
+            .build();
+        upgrade.config(config).on_upgrade(move |socket| async move {
+            let (mut reader, _writer) = socket.split();
+            while let Some(message) = reader.next().await {
+                if matches!(message, Ok(Message::Pong(_))) {
+                    state.pong_seen.notify_one();
+                }
+            }
+        })
+    }
+
+    async fn read_server_control_frame(
+        stream: &mut tokio::net::TcpStream,
+        expected_opcode: u8,
+    ) -> Vec<u8> {
+        use tokio::io::AsyncReadExt;
+
+        let mut header = [0_u8; 2];
+        stream.read_exact(&mut header).await.unwrap();
+        assert_eq!(header[0], 0x80 | expected_opcode);
+        assert_eq!(header[1] & 0x80, 0, "server frames must be unmasked");
+        let len = usize::from(header[1] & 0x7f);
+        assert!(len <= 125);
+        let mut payload = vec![0; len];
+        stream.read_exact(&mut payload).await.unwrap();
+        payload
+    }
+
+    async fn send_masked_pong(stream: &mut tokio::net::TcpStream, payload: &[u8]) {
+        use tokio::io::AsyncWriteExt;
+
+        let mask = [0x11, 0x22, 0x33, 0x44];
+        let mut frame = Vec::with_capacity(6 + payload.len());
+        frame.push(0x8a);
+        frame.push(0x80 | payload.len() as u8);
+        frame.extend_from_slice(&mask);
+        frame.extend(
+            payload
+                .iter()
+                .enumerate()
+                .map(|(index, byte)| byte ^ mask[index % 4]),
+        );
+        stream.write_all(&frame).await.unwrap();
+        stream.flush().await.unwrap();
+    }
+
+    async fn connect_raw_websocket(
+        address: std::net::SocketAddr,
+        path: &str,
+        deflate: bool,
+    ) -> tokio::net::TcpStream {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let mut stream = tokio::net::TcpStream::connect(address).await.unwrap();
+        let extension = if deflate {
+            "Sec-WebSocket-Extensions: permessage-deflate; client_max_window_bits\r\n"
+        } else {
+            ""
+        };
+        let request = format!(
+            "GET {path} HTTP/1.1\r\n\
+             Host: {address}\r\n\
+             Upgrade: websocket\r\n\
+             Connection: Upgrade\r\n\
+             Sec-WebSocket-Version: 13\r\n\
+             Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n\
+             {extension}\r\n"
+        );
+        stream.write_all(request.as_bytes()).await.unwrap();
+        stream.flush().await.unwrap();
+
+        let mut response = Vec::new();
+        let mut byte = [0_u8; 1];
+        while !response.ends_with(b"\r\n\r\n") {
+            stream.read_exact(&mut byte).await.unwrap();
+            response.push(byte[0]);
+        }
+        let response = String::from_utf8(response).unwrap();
+        assert!(response.starts_with("HTTP/1.1 101"));
+        if deflate {
+            assert!(
+                response
+                    .to_ascii_lowercase()
+                    .contains("sec-websocket-extensions: permessage-deflate")
+            );
+        }
+        stream
+    }
+
+    async fn assert_axum_split_heartbeat(
+        address: std::net::SocketAddr,
+        path: &str,
+        deflate: bool,
+        state: &HeartbeatTestState,
+    ) {
+        let mut stream = connect_raw_websocket(address, path, deflate).await;
+        tokio::time::pause();
+        tokio::task::yield_now().await;
+
+        tokio::time::advance(std::time::Duration::from_secs(1)).await;
+        let first_ping = read_server_control_frame(&mut stream, 0x09).await;
+        assert_eq!(first_ping.len(), 8);
+        send_masked_pong(&mut stream, &first_ping).await;
+        tokio::time::resume();
+        state.pong_seen.notified().await;
+        tokio::time::pause();
+
+        tokio::time::advance(std::time::Duration::from_secs(1)).await;
+        let second_ping = read_server_control_frame(&mut stream, 0x09).await;
+        assert_eq!(second_ping.len(), 8);
+        assert_ne!(first_ping, second_ping);
+
+        tokio::time::advance(std::time::Duration::from_secs(1)).await;
+        let close = read_server_control_frame(&mut stream, 0x08).await;
+        assert_eq!(u16::from_be_bytes([close[0], close[1]]), 4201);
+        assert_eq!(&close[2..], b"Pong reply not received in time");
+        tokio::time::resume();
+    }
+
+    #[cfg(feature = "permessage-deflate")]
+    #[tokio::test]
+    async fn axum_split_native_heartbeat_plain_and_deflate() {
+        use axum::{Router, routing::get};
+
+        let state = std::sync::Arc::new(HeartbeatTestState::default());
+        let app = Router::new()
+            .route("/plain", get(plain_heartbeat_handler))
+            .route("/deflate", get(compressed_heartbeat_handler))
+            .with_state(state.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        assert_axum_split_heartbeat(address, "/plain", false, &state).await;
+        assert_axum_split_heartbeat(address, "/deflate", true, &state).await;
+        server.abort();
+    }
+
     #[cfg(feature = "permessage-deflate")]
     #[test]
     fn test_deflate_negotiation_with_client_offer() {

--- a/src/compio.rs
+++ b/src/compio.rs
@@ -4,12 +4,15 @@
 //! from Tokio's poll-based `AsyncRead` and `AsyncWrite`. This module exposes a
 //! native async-method API for Compio streams instead of adapting through Tokio.
 
+use std::cell::Cell;
 #[cfg(any(feature = "http2", feature = "http3"))]
 use std::future::Future;
 use std::io;
+use std::marker::PhantomData;
 #[cfg(feature = "http2")]
 use std::pin::Pin;
-use std::sync::mpsc;
+use std::rc::Rc;
+use std::time::{Duration, Instant};
 
 #[cfg(any(feature = "http2", feature = "http3"))]
 use ::compio::buf::IoBufMut;
@@ -19,6 +22,8 @@ use ::compio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 #[cfg(any(feature = "http2", feature = "http3"))]
 use bytes::Buf;
 use bytes::{Bytes, BytesMut};
+use futures_channel::{mpsc, oneshot};
+use futures_util::{FutureExt, SinkExt, StreamExt};
 
 use crate::Config;
 use crate::error::{CloseReason, Error, Result};
@@ -26,6 +31,7 @@ use crate::handshake::{
     HandshakeResult, build_request, build_response, generate_accept_key, generate_key,
     parse_request, parse_response, validate_accept_key,
 };
+use crate::heartbeat::{Deadline, Heartbeat, bounded_close_reason};
 use crate::protocol::{Message, Protocol, Role};
 
 #[cfg(any(feature = "http2", feature = "http3"))]
@@ -53,10 +59,77 @@ enum CompioStreamState {
     Closed,
 }
 
+const SPLIT_CONTROL_CAPACITY: usize = 32;
+const SPLIT_APPLICATION_CAPACITY: usize = 32;
+const SPLIT_OPEN: u8 = 0;
+const SPLIT_CLOSING: u8 = 1;
+const SPLIT_CLOSED: u8 = 2;
+
 #[derive(Debug, Clone)]
 enum ControlRequest {
-    Pong(Bytes),
-    CloseResponse,
+    Activity(Instant),
+    Pong(Bytes, Instant),
+    PeerPing(Bytes, Instant),
+    PeerClose,
+    Eof,
+}
+
+#[derive(Debug)]
+enum ApplicationRequest {
+    Send(Message, oneshot::Sender<Result<()>>),
+    Flush(oneshot::Sender<Result<()>>),
+}
+
+enum CompioReadOutcome {
+    Read(io::Result<usize>),
+    Terminal(Option<CompioTerminalCause>),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CompioTerminalCause {
+    ConnectionClosed,
+    HeartbeatTimeout,
+    IdleTimeout,
+}
+
+impl CompioTerminalCause {
+    fn error(self) -> Error {
+        match self {
+            Self::ConnectionClosed => Error::ConnectionClosed,
+            Self::HeartbeatTimeout => Error::HeartbeatTimeout,
+            Self::IdleTimeout => Error::IdleTimeout,
+        }
+    }
+}
+
+struct CompioSplitShared {
+    status: Cell<u8>,
+    terminal: Cell<Option<CompioTerminalCause>>,
+}
+
+impl CompioSplitShared {
+    fn new(closed: bool) -> Rc<Self> {
+        Rc::new(Self {
+            status: Cell::new(if closed { SPLIT_CLOSED } else { SPLIT_OPEN }),
+            terminal: Cell::new(closed.then_some(CompioTerminalCause::ConnectionClosed)),
+        })
+    }
+
+    fn is_open(&self) -> bool {
+        self.status.get() == SPLIT_OPEN
+    }
+
+    fn begin_closing(&self) {
+        if self.is_open() {
+            self.status.set(SPLIT_CLOSING);
+        }
+    }
+
+    fn terminate(&self, cause: CompioTerminalCause) {
+        if self.status.replace(SPLIT_CLOSED) != SPLIT_CLOSED {
+            self.terminal.set(Some(cause));
+        }
+    }
 }
 
 async fn read_more<R>(reader: &mut R, buf: &mut BytesMut) -> io::Result<usize>
@@ -98,6 +171,26 @@ where
 
     writer.flush().await?;
     Ok(())
+}
+
+trait CompioSplitEncoder: 'static {
+    fn encode_message(&mut self, msg: &Message, buf: &mut BytesMut) -> Result<()>;
+    fn encode_pong(&mut self, payload: &[u8], buf: &mut BytesMut);
+    fn encode_close_response(&mut self, buf: &mut BytesMut);
+}
+
+impl CompioSplitEncoder for Protocol {
+    fn encode_message(&mut self, msg: &Message, buf: &mut BytesMut) -> Result<()> {
+        Protocol::encode_message(self, msg, buf)
+    }
+
+    fn encode_pong(&mut self, payload: &[u8], buf: &mut BytesMut) {
+        Protocol::encode_pong(self, payload, buf);
+    }
+
+    fn encode_close_response(&mut self, buf: &mut BytesMut) {
+        Protocol::encode_close_response(self, buf);
+    }
 }
 
 /// Perform a server-side WebSocket handshake over a Compio stream.
@@ -1015,6 +1108,8 @@ pub struct CompioWebSocketStream<S> {
     config: Config,
     pending_messages: Vec<Message>,
     pending_index: usize,
+    clock_epoch: Instant,
+    heartbeat: Heartbeat,
     high_water_mark: usize,
     low_water_mark: usize,
 }
@@ -1040,6 +1135,8 @@ where
             read_buf.extend_from_slice(&leftover);
         }
 
+        let clock_epoch = Instant::now();
+        let heartbeat = Heartbeat::new(&config, 0);
         Self {
             inner,
             protocol: Protocol::new(role, config.max_frame_size, config.max_message_size),
@@ -1049,6 +1146,8 @@ where
             config,
             pending_messages: Vec::new(),
             pending_index: 0,
+            clock_epoch,
+            heartbeat,
             high_water_mark: DEFAULT_HIGH_WATER_MARK,
             low_water_mark: DEFAULT_LOW_WATER_MARK,
         }
@@ -1142,22 +1241,107 @@ where
             }
 
             if let Some(msg) = self.next_pending_message() {
+                let now = self.clock_epoch.elapsed().as_millis() as u64;
+                let pong = match &msg {
+                    Message::Pong(payload) => Some(payload),
+                    _ => None,
+                };
+                self.heartbeat.on_inbound(now, pong);
                 return Some(self.handle_incoming_message(msg).await);
             }
 
             match self.process_read_buf() {
                 Ok(true) => continue,
                 Ok(false) => {}
-                Err(e) => return Some(Err(e)),
+                Err(e) => {
+                    self.heartbeat.stop();
+                    self.state = CompioStreamState::Closed;
+                    return Some(Err(e));
+                }
             }
 
-            match read_more(&mut self.inner, &mut self.read_buf).await {
+            let read_result = if let Some(deadline) = self.heartbeat.next_deadline() {
+                let now = self.clock_epoch.elapsed().as_millis() as u64;
+                let delay = Duration::from_millis(deadline.at().saturating_sub(now));
+                match ::compio::time::timeout(delay, read_more(&mut self.inner, &mut self.read_buf))
+                    .await
+                {
+                    Ok(result) => Some(result),
+                    Err(_) => {
+                        let now = self.clock_epoch.elapsed().as_millis() as u64;
+                        match self.heartbeat.next_deadline() {
+                            Some(Deadline::Ping(at)) if at <= now => {
+                                if let Some(payload) = self.heartbeat.ping_due(now) {
+                                    if let Err(error) = self.protocol.encode_message(
+                                        &Message::Ping(payload),
+                                        &mut self.write_buf,
+                                    ) {
+                                        return Some(Err(error));
+                                    }
+                                    if let Err(error) = self.flush().await {
+                                        return Some(Err(error));
+                                    }
+                                    self.heartbeat.ping_flushed(
+                                        self.clock_epoch.elapsed().as_millis() as u64,
+                                    );
+                                }
+                                None
+                            }
+                            Some(Deadline::Pong(at)) if at <= now => {
+                                self.heartbeat.stop();
+                                self.state = CompioStreamState::CloseSent;
+                                let close = Message::Close(Some(CloseReason::new(
+                                    self.config.pong_timeout_close_code,
+                                    bounded_close_reason(&self.config.pong_timeout_close_reason),
+                                )));
+                                let _ = self.protocol.encode_message(&close, &mut self.write_buf);
+                                let _ = ::compio::time::timeout(
+                                    Duration::from_secs(self.config.close_timeout.into()),
+                                    self.flush(),
+                                )
+                                .await;
+                                self.state = CompioStreamState::Closed;
+                                return Some(Err(Error::HeartbeatTimeout));
+                            }
+                            Some(Deadline::Idle(at)) if at <= now => {
+                                self.heartbeat.stop();
+                                self.state = CompioStreamState::CloseSent;
+                                let close = Message::Close(Some(CloseReason::new(
+                                    CloseReason::GOING_AWAY,
+                                    "Connection idle timeout",
+                                )));
+                                let _ = self.protocol.encode_message(&close, &mut self.write_buf);
+                                let _ = ::compio::time::timeout(
+                                    Duration::from_secs(self.config.close_timeout.into()),
+                                    self.flush(),
+                                )
+                                .await;
+                                self.state = CompioStreamState::Closed;
+                                return Some(Err(Error::IdleTimeout));
+                            }
+                            _ => None,
+                        }
+                    }
+                }
+            } else {
+                Some(read_more(&mut self.inner, &mut self.read_buf).await)
+            };
+
+            let Some(read_result) = read_result else {
+                continue;
+            };
+            match read_result {
                 Ok(0) => {
+                    self.heartbeat.stop();
                     self.state = CompioStreamState::Closed;
                     return None;
                 }
                 Ok(_) => {}
-                Err(e) => return Some(Err(e.into())),
+                Err(e) => {
+                    self.heartbeat.stop();
+                    self.state = CompioStreamState::Closed;
+                    return Some(Err(e.into()));
+                }
             }
         }
     }
@@ -1170,10 +1354,16 @@ where
 
         if msg.is_close() {
             self.state = CompioStreamState::CloseSent;
+            self.heartbeat.stop();
         }
 
         self.protocol.encode_message(&msg, &mut self.write_buf)?;
-        self.flush().await
+        if let Err(error) = self.flush().await {
+            self.heartbeat.stop();
+            self.state = CompioStreamState::Closed;
+            return Err(error);
+        }
+        Ok(())
     }
 
     /// Send a text message.
@@ -1234,12 +1424,20 @@ where
         match &msg {
             Message::Ping(data) => {
                 self.protocol.encode_pong(data, &mut self.write_buf);
-                self.flush().await?;
+                if let Err(error) = self.flush().await {
+                    self.heartbeat.stop();
+                    self.state = CompioStreamState::Closed;
+                    return Err(error);
+                }
             }
             Message::Close(reason) => {
+                self.heartbeat.stop();
                 if self.state == CompioStreamState::Open {
                     self.protocol.encode_close_response(&mut self.write_buf);
-                    self.flush().await?;
+                    if let Err(error) = self.flush().await {
+                        self.state = CompioStreamState::Closed;
+                        return Err(error);
+                    }
                 }
                 self.state = CompioStreamState::Closed;
                 return Ok(Message::Close(reason.clone()));
@@ -1255,7 +1453,7 @@ impl<S> CompioWebSocketStream<S>
 where
     S: Splittable,
     S::ReadHalf: AsyncRead,
-    S::WriteHalf: AsyncWrite,
+    S::WriteHalf: AsyncWrite + 'static,
 {
     /// Split the WebSocket stream into independent Compio read and write halves.
     pub fn split(
@@ -1265,13 +1463,31 @@ where
         CompioSplitWriter<S::WriteHalf>,
     ) {
         let (reader, writer) = Splittable::split(self.inner);
-        let (control_tx, control_rx) = mpsc::channel();
+        let (control_tx, control_rx) = mpsc::channel(SPLIT_CONTROL_CAPACITY);
+        let (application_tx, application_rx) = mpsc::channel(SPLIT_APPLICATION_CAPACITY);
+        let (cancel_tx, cancel_rx) = mpsc::unbounded();
+        let (terminal_tx, terminal_rx) = mpsc::unbounded();
+        let shared = CompioSplitShared::new(self.state != CompioStreamState::Open);
 
         let reader_protocol = Protocol::new(
             self.protocol.role,
             self.config.max_frame_size,
             self.config.max_message_size,
         );
+
+        ::compio::runtime::spawn(compio_split_writer_driver(
+            writer,
+            self.protocol,
+            self.config,
+            CompioDriverChannels {
+                control_rx,
+                application_rx,
+                cancel_rx,
+                terminal_tx,
+                shared: shared.clone(),
+            },
+        ))
+        .detach();
 
         (
             CompioSplitReader {
@@ -1281,14 +1497,16 @@ where
                 pending_messages: self.pending_messages,
                 pending_index: self.pending_index,
                 control_tx,
-                closed: self.state == CompioStreamState::Closed,
+                terminal_rx,
+                cancel_tx: cancel_tx.clone(),
+                shared: shared.clone(),
+                terminal_reported: false,
             },
             CompioSplitWriter {
-                writer,
-                protocol: self.protocol,
-                write_buf: BytesMut::with_capacity(self.config.write_buffer_size),
-                control_rx,
-                closed: self.state == CompioStreamState::Closed,
+                application_tx,
+                cancel_tx,
+                shared,
+                _writer: PhantomData,
             },
         )
     }
@@ -1375,27 +1593,39 @@ pub struct CompioSplitReader<R> {
     pending_messages: Vec<Message>,
     pending_index: usize,
     control_tx: mpsc::Sender<ControlRequest>,
-    closed: bool,
+    terminal_rx: mpsc::UnboundedReceiver<CompioTerminalCause>,
+    cancel_tx: mpsc::UnboundedSender<()>,
+    shared: Rc<CompioSplitShared>,
+    terminal_reported: bool,
 }
 
 /// Write half of a split Compio WebSocket stream.
 pub struct CompioSplitWriter<W> {
-    writer: W,
-    protocol: Protocol,
-    write_buf: BytesMut,
-    control_rx: mpsc::Receiver<ControlRequest>,
-    closed: bool,
+    application_tx: mpsc::Sender<ApplicationRequest>,
+    cancel_tx: mpsc::UnboundedSender<()>,
+    shared: Rc<CompioSplitShared>,
+    _writer: PhantomData<fn() -> W>,
 }
 
 impl<R> CompioSplitReader<R>
 where
     R: AsyncRead,
 {
-    /// Receive the next non-control message.
+    /// Receive the next message, including Ping and Pong control frames.
     pub async fn next(&mut self) -> Option<Result<Message>> {
         loop {
-            if self.closed {
-                return None;
+            if self.shared.status.get() == SPLIT_CLOSED {
+                if self.terminal_reported {
+                    return None;
+                }
+                self.terminal_reported = true;
+                return match self.shared.terminal.get() {
+                    Some(CompioTerminalCause::HeartbeatTimeout) => {
+                        Some(Err(Error::HeartbeatTimeout))
+                    }
+                    Some(CompioTerminalCause::IdleTimeout) => Some(Err(Error::IdleTimeout)),
+                    _ => None,
+                };
             }
 
             if self.pending_index < self.pending_messages.len() {
@@ -1407,21 +1637,20 @@ where
                     self.pending_index = 0;
                 }
 
-                match &msg {
-                    Message::Ping(data) => {
-                        let _ = self.control_tx.send(ControlRequest::Pong(data.clone()));
-                        continue;
+                let request = match &msg {
+                    Message::Ping(data) => ControlRequest::PeerPing(data.clone(), Instant::now()),
+                    Message::Pong(data) => ControlRequest::Pong(data.clone(), Instant::now()),
+                    Message::Close(_) => {
+                        self.shared.begin_closing();
+                        ControlRequest::PeerClose
                     }
-                    Message::Close(reason) => {
-                        if !self.closed {
-                            let _ = self.control_tx.send(ControlRequest::CloseResponse);
-                            self.closed = true;
-                        }
-                        return Some(Ok(Message::Close(reason.clone())));
-                    }
-                    Message::Pong(_) => continue,
-                    _ => return Some(Ok(msg)),
+                    _ => ControlRequest::Activity(Instant::now()),
+                };
+                if self.control_tx.send(request).await.is_err() {
+                    self.shared.terminate(CompioTerminalCause::ConnectionClosed);
+                    continue;
                 }
+                return Some(Ok(msg));
             }
 
             if !self.read_buf.is_empty() {
@@ -1432,45 +1661,67 @@ where
                         continue;
                     }
                     Ok(_) => {}
-                    Err(e) => return Some(Err(e)),
+                    Err(e) => {
+                        self.shared.terminate(CompioTerminalCause::ConnectionClosed);
+                        return Some(Err(e));
+                    }
                 }
             }
 
-            match read_more(&mut self.reader, &mut self.read_buf).await {
-                Ok(0) => {
-                    self.closed = true;
-                    return None;
+            let outcome = {
+                let read = read_more(&mut self.reader, &mut self.read_buf).fuse();
+                let terminal = self.terminal_rx.next().fuse();
+                futures_util::pin_mut!(read, terminal);
+                futures_util::select_biased! {
+                    cause = terminal => CompioReadOutcome::Terminal(cause),
+                    result = read => CompioReadOutcome::Read(result),
                 }
-                Ok(_) => {}
-                Err(e) => return Some(Err(e.into())),
+            };
+            match outcome {
+                CompioReadOutcome::Read(Ok(0)) => {
+                    let _ = self.control_tx.send(ControlRequest::Eof).await;
+                    self.shared.terminate(CompioTerminalCause::ConnectionClosed);
+                }
+                CompioReadOutcome::Read(Ok(_)) => {}
+                CompioReadOutcome::Read(Err(error)) => {
+                    self.shared.terminate(CompioTerminalCause::ConnectionClosed);
+                    return Some(Err(error.into()));
+                }
+                CompioReadOutcome::Terminal(cause) => {
+                    if let Some(cause) = cause {
+                        self.shared.terminate(cause);
+                    } else {
+                        self.shared.terminate(CompioTerminalCause::ConnectionClosed);
+                    }
+                }
             }
         }
     }
 
     /// Check whether the reader is closed.
     pub fn is_closed(&self) -> bool {
-        self.closed
+        !self.shared.is_open()
     }
 }
 
-impl<W> CompioSplitWriter<W>
-where
-    W: AsyncWrite,
-{
+impl<R> Drop for CompioSplitReader<R> {
+    fn drop(&mut self) {
+        let _ = self.cancel_tx.unbounded_send(());
+    }
+}
+
+impl<W> CompioSplitWriter<W> {
     /// Send a WebSocket message.
     pub async fn send(&mut self, msg: Message) -> Result<()> {
-        if self.closed {
-            return Err(Error::ConnectionClosed);
+        if !self.shared.is_open() {
+            return Err(self.current_error());
         }
-
-        self.process_control_requests().await?;
-
-        if msg.is_close() {
-            self.closed = true;
-        }
-
-        self.protocol.encode_message(&msg, &mut self.write_buf)?;
-        self.flush().await
+        let (tx, rx) = oneshot::channel();
+        self.application_tx
+            .send(ApplicationRequest::Send(msg, tx))
+            .await
+            .map_err(|_| self.current_error())?;
+        rx.await.map_err(|_| self.current_error())?
     }
 
     /// Send a text message.
@@ -1491,33 +1742,322 @@ where
 
     /// Flush pending data and control responses.
     pub async fn flush(&mut self) -> Result<()> {
-        self.process_control_requests().await?;
-        flush_bytes(&mut self.writer, &mut self.write_buf).await
+        if !self.shared.is_open() {
+            return Err(self.current_error());
+        }
+        let (tx, rx) = oneshot::channel();
+        self.application_tx
+            .send(ApplicationRequest::Flush(tx))
+            .await
+            .map_err(|_| self.current_error())?;
+        rx.await.map_err(|_| self.current_error())?
     }
 
     /// Check whether the writer is closed.
     pub fn is_closed(&self) -> bool {
-        self.closed
+        !self.shared.is_open()
     }
 
-    async fn process_control_requests(&mut self) -> Result<()> {
-        while let Ok(req) = self.control_rx.try_recv() {
-            match req {
-                ControlRequest::Pong(data) => {
-                    self.protocol.encode_pong(&data, &mut self.write_buf);
+    fn current_error(&self) -> Error {
+        self.shared
+            .terminal
+            .get()
+            .map_or(Error::ConnectionClosed, CompioTerminalCause::error)
+    }
+}
+
+impl<W> Drop for CompioSplitWriter<W> {
+    fn drop(&mut self) {
+        let _ = self.cancel_tx.unbounded_send(());
+    }
+}
+
+enum CompioDriverWake {
+    Cancel,
+    Control(Option<ControlRequest>),
+    Application(Option<ApplicationRequest>),
+    Timer,
+}
+
+struct CompioDriverChannels {
+    control_rx: mpsc::Receiver<ControlRequest>,
+    application_rx: mpsc::Receiver<ApplicationRequest>,
+    cancel_rx: mpsc::UnboundedReceiver<()>,
+    terminal_tx: mpsc::UnboundedSender<CompioTerminalCause>,
+    shared: Rc<CompioSplitShared>,
+}
+
+async fn compio_split_writer_driver<W, E>(
+    mut writer: W,
+    mut encoder: E,
+    config: Config,
+    channels: CompioDriverChannels,
+) where
+    W: AsyncWrite,
+    E: CompioSplitEncoder,
+{
+    let CompioDriverChannels {
+        mut control_rx,
+        mut application_rx,
+        mut cancel_rx,
+        terminal_tx,
+        shared,
+    } = channels;
+    let epoch = Instant::now();
+    let mut heartbeat = Heartbeat::new(&config, 0);
+    let mut closing_deadline: Option<Instant> = None;
+    let mut local_close_sent = false;
+    let mut write_buf = BytesMut::with_capacity(config.write_buffer_size);
+
+    loop {
+        let now_ms = epoch.elapsed().as_millis() as u64;
+        let heartbeat_delay = heartbeat
+            .next_deadline()
+            .map(|deadline| Duration::from_millis(deadline.at().saturating_sub(now_ms)))
+            .unwrap_or(Duration::from_secs(365 * 24 * 60 * 60));
+        let close_delay = closing_deadline
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+            .unwrap_or(Duration::from_secs(365 * 24 * 60 * 60));
+        let timer_delay = heartbeat_delay.min(close_delay);
+
+        let wake = {
+            let cancel = cancel_rx.next().fuse();
+            let control = control_rx.next().fuse();
+            let application = application_rx.next().fuse();
+            let timer = ::compio::time::sleep(timer_delay).fuse();
+            futures_util::pin_mut!(cancel, control, application, timer);
+            futures_util::select_biased! {
+                _ = cancel => CompioDriverWake::Cancel,
+                request = control => CompioDriverWake::Control(request),
+                request = application => CompioDriverWake::Application(request),
+                _ = timer => CompioDriverWake::Timer,
+            }
+        };
+
+        match wake {
+            CompioDriverWake::Cancel => {
+                compio_terminate(&shared, &terminal_tx, CompioTerminalCause::ConnectionClosed);
+                break;
+            }
+            CompioDriverWake::Control(None) => {
+                compio_terminate(&shared, &terminal_tx, CompioTerminalCause::ConnectionClosed);
+                break;
+            }
+            CompioDriverWake::Control(Some(request)) => match request {
+                ControlRequest::Activity(received_at) => {
+                    let received_ms =
+                        received_at.saturating_duration_since(epoch).as_millis() as u64;
+                    heartbeat.on_inbound(received_ms, None);
                 }
-                ControlRequest::CloseResponse => {
-                    self.protocol.encode_close_response(&mut self.write_buf);
-                    self.closed = true;
+                ControlRequest::Pong(payload, received_at) => {
+                    let received_ms =
+                        received_at.saturating_duration_since(epoch).as_millis() as u64;
+                    heartbeat.on_inbound(received_ms, Some(&payload));
+                }
+                ControlRequest::PeerPing(payload, received_at) => {
+                    let received_ms =
+                        received_at.saturating_duration_since(epoch).as_millis() as u64;
+                    heartbeat.on_inbound(received_ms, None);
+                    write_buf.clear();
+                    encoder.encode_pong(&payload, &mut write_buf);
+                    if compio_cancellable_flush(&mut writer, &mut write_buf, &mut cancel_rx)
+                        .await
+                        .is_err()
+                    {
+                        compio_terminate(
+                            &shared,
+                            &terminal_tx,
+                            CompioTerminalCause::ConnectionClosed,
+                        );
+                        break;
+                    }
+                }
+                ControlRequest::PeerClose => {
+                    heartbeat.stop();
+                    if !local_close_sent {
+                        write_buf.clear();
+                        encoder.encode_close_response(&mut write_buf);
+                        let _ = ::compio::time::timeout(
+                            Duration::from_secs(config.close_timeout.into()),
+                            flush_bytes(&mut writer, &mut write_buf),
+                        )
+                        .await;
+                    }
+                    compio_terminate(&shared, &terminal_tx, CompioTerminalCause::ConnectionClosed);
+                    break;
+                }
+                ControlRequest::Eof => {
+                    heartbeat.stop();
+                    compio_terminate(&shared, &terminal_tx, CompioTerminalCause::ConnectionClosed);
+                    break;
+                }
+            },
+            CompioDriverWake::Application(None) => {
+                compio_terminate(&shared, &terminal_tx, CompioTerminalCause::ConnectionClosed);
+                break;
+            }
+            CompioDriverWake::Application(Some(request)) => match request {
+                ApplicationRequest::Send(message, completion) => {
+                    if !shared.is_open() {
+                        let _ = completion.send(Err(Error::ConnectionClosed));
+                        continue;
+                    }
+                    let is_close = message.is_close();
+                    if is_close {
+                        shared.begin_closing();
+                        heartbeat.stop();
+                        local_close_sent = true;
+                    }
+                    write_buf.clear();
+                    let result = match encoder.encode_message(&message, &mut write_buf) {
+                        Ok(()) => {
+                            compio_cancellable_flush(&mut writer, &mut write_buf, &mut cancel_rx)
+                                .await
+                        }
+                        Err(error) => Err(error),
+                    };
+                    let failed = result.is_err();
+                    let _ = completion.send(result);
+                    if failed {
+                        compio_terminate(
+                            &shared,
+                            &terminal_tx,
+                            CompioTerminalCause::ConnectionClosed,
+                        );
+                        break;
+                    }
+                    if is_close {
+                        closing_deadline =
+                            Some(Instant::now() + Duration::from_secs(config.close_timeout.into()));
+                    }
+                }
+                ApplicationRequest::Flush(completion) => {
+                    write_buf.clear();
+                    let result =
+                        compio_cancellable_flush(&mut writer, &mut write_buf, &mut cancel_rx).await;
+                    let failed = result.is_err();
+                    let _ = completion.send(result);
+                    if failed {
+                        compio_terminate(
+                            &shared,
+                            &terminal_tx,
+                            CompioTerminalCause::ConnectionClosed,
+                        );
+                        break;
+                    }
+                }
+            },
+            CompioDriverWake::Timer => {
+                if closing_deadline.is_some_and(|deadline| deadline <= Instant::now()) {
+                    compio_terminate(&shared, &terminal_tx, CompioTerminalCause::ConnectionClosed);
+                    break;
+                }
+
+                let now_ms = epoch.elapsed().as_millis() as u64;
+                match heartbeat.next_deadline() {
+                    Some(Deadline::Ping(at)) if at <= now_ms => {
+                        if let Some(payload) = heartbeat.ping_due(now_ms) {
+                            write_buf.clear();
+                            let result =
+                                encoder.encode_message(&Message::Ping(payload), &mut write_buf);
+                            if result.is_err()
+                                || compio_cancellable_flush(
+                                    &mut writer,
+                                    &mut write_buf,
+                                    &mut cancel_rx,
+                                )
+                                .await
+                                .is_err()
+                            {
+                                compio_terminate(
+                                    &shared,
+                                    &terminal_tx,
+                                    CompioTerminalCause::ConnectionClosed,
+                                );
+                                break;
+                            }
+                            heartbeat.ping_flushed(epoch.elapsed().as_millis() as u64);
+                        }
+                    }
+                    Some(Deadline::Pong(at)) if at <= now_ms => {
+                        compio_timeout_close(
+                            &mut writer,
+                            &mut encoder,
+                            &config,
+                            config.pong_timeout_close_code,
+                            &config.pong_timeout_close_reason,
+                        )
+                        .await;
+                        compio_terminate(
+                            &shared,
+                            &terminal_tx,
+                            CompioTerminalCause::HeartbeatTimeout,
+                        );
+                        break;
+                    }
+                    Some(Deadline::Idle(at)) if at <= now_ms => {
+                        compio_timeout_close(
+                            &mut writer,
+                            &mut encoder,
+                            &config,
+                            CloseReason::GOING_AWAY,
+                            "Connection idle timeout",
+                        )
+                        .await;
+                        compio_terminate(&shared, &terminal_tx, CompioTerminalCause::IdleTimeout);
+                        break;
+                    }
+                    _ => {}
                 }
             }
         }
+    }
+}
 
-        if !self.write_buf.is_empty() {
-            flush_bytes(&mut self.writer, &mut self.write_buf).await?;
-        }
+async fn compio_cancellable_flush<W>(
+    writer: &mut W,
+    buf: &mut BytesMut,
+    cancel_rx: &mut mpsc::UnboundedReceiver<()>,
+) -> Result<()>
+where
+    W: AsyncWrite,
+{
+    let write = flush_bytes(writer, buf).fuse();
+    let cancel = cancel_rx.next().fuse();
+    futures_util::pin_mut!(write, cancel);
+    match futures_util::future::select(write, cancel).await {
+        futures_util::future::Either::Left((result, _)) => result,
+        futures_util::future::Either::Right((_, _)) => Err(Error::ConnectionClosed),
+    }
+}
 
-        Ok(())
+fn compio_terminate(
+    shared: &CompioSplitShared,
+    terminal_tx: &mpsc::UnboundedSender<CompioTerminalCause>,
+    cause: CompioTerminalCause,
+) {
+    shared.terminate(cause);
+    let _ = terminal_tx.unbounded_send(cause);
+}
+
+async fn compio_timeout_close<W, E>(
+    writer: &mut W,
+    encoder: &mut E,
+    config: &Config,
+    code: u16,
+    reason: &str,
+) where
+    W: AsyncWrite,
+    E: CompioSplitEncoder,
+{
+    let mut buf = BytesMut::with_capacity(128);
+    let close = Message::Close(Some(CloseReason::new(code, bounded_close_reason(reason))));
+    if encoder.encode_message(&close, &mut buf).is_ok() {
+        let _ = ::compio::time::timeout(
+            Duration::from_secs(config.close_timeout.into()),
+            flush_bytes(writer, &mut buf),
+        )
+        .await;
     }
 }
 
@@ -1530,6 +2070,21 @@ use crate::deflate::DeflateConfig;
 #[cfg(feature = "permessage-deflate")]
 use crate::protocol::{CompressedProtocol, CompressedReaderProtocol, CompressedWriterProtocol};
 
+#[cfg(feature = "permessage-deflate")]
+impl CompioSplitEncoder for CompressedWriterProtocol {
+    fn encode_message(&mut self, msg: &Message, buf: &mut BytesMut) -> Result<()> {
+        CompressedWriterProtocol::encode_message(self, msg, buf)
+    }
+
+    fn encode_pong(&mut self, payload: &[u8], buf: &mut BytesMut) {
+        CompressedWriterProtocol::encode_pong(self, payload, buf);
+    }
+
+    fn encode_close_response(&mut self, buf: &mut BytesMut) {
+        CompressedWriterProtocol::encode_close_response(self, buf);
+    }
+}
+
 /// A compressed WebSocket stream over a native Compio transport.
 #[cfg(feature = "permessage-deflate")]
 pub struct CompioCompressedWebSocketStream<S> {
@@ -1541,6 +2096,8 @@ pub struct CompioCompressedWebSocketStream<S> {
     config: Config,
     pending_messages: Vec<Message>,
     pending_index: usize,
+    clock_epoch: Instant,
+    heartbeat: Heartbeat,
     high_water_mark: usize,
     low_water_mark: usize,
 }
@@ -1567,6 +2124,8 @@ where
             read_buf.extend_from_slice(&leftover);
         }
 
+        let clock_epoch = Instant::now();
+        let heartbeat = Heartbeat::new(&config, 0);
         Self {
             inner,
             protocol: CompressedProtocol::server(
@@ -1580,6 +2139,8 @@ where
             config,
             pending_messages: Vec::new(),
             pending_index: 0,
+            clock_epoch,
+            heartbeat,
             high_water_mark: DEFAULT_HIGH_WATER_MARK,
             low_water_mark: DEFAULT_LOW_WATER_MARK,
         }
@@ -1602,6 +2163,8 @@ where
             read_buf.extend_from_slice(&leftover);
         }
 
+        let clock_epoch = Instant::now();
+        let heartbeat = Heartbeat::new(&config, 0);
         Self {
             inner,
             protocol: CompressedProtocol::client(
@@ -1615,6 +2178,8 @@ where
             config,
             pending_messages: Vec::new(),
             pending_index: 0,
+            clock_epoch,
+            heartbeat,
             high_water_mark: DEFAULT_HIGH_WATER_MARK,
             low_water_mark: DEFAULT_LOW_WATER_MARK,
         }
@@ -1628,22 +2193,106 @@ where
             }
 
             if let Some(msg) = self.next_pending_message() {
+                let now = self.clock_epoch.elapsed().as_millis() as u64;
+                let pong = match &msg {
+                    Message::Pong(payload) => Some(payload),
+                    _ => None,
+                };
+                self.heartbeat.on_inbound(now, pong);
                 return Some(self.handle_incoming_message(msg).await);
             }
 
             match self.process_read_buf() {
                 Ok(true) => continue,
                 Ok(false) => {}
-                Err(e) => return Some(Err(e)),
+                Err(e) => {
+                    self.heartbeat.stop();
+                    self.state = CompioStreamState::Closed;
+                    return Some(Err(e));
+                }
             }
 
-            match read_more(&mut self.inner, &mut self.read_buf).await {
+            let read_result = if let Some(deadline) = self.heartbeat.next_deadline() {
+                let now = self.clock_epoch.elapsed().as_millis() as u64;
+                let delay = Duration::from_millis(deadline.at().saturating_sub(now));
+                match ::compio::time::timeout(delay, read_more(&mut self.inner, &mut self.read_buf))
+                    .await
+                {
+                    Ok(result) => Some(result),
+                    Err(_) => {
+                        let now = self.clock_epoch.elapsed().as_millis() as u64;
+                        match self.heartbeat.next_deadline() {
+                            Some(Deadline::Ping(at)) if at <= now => {
+                                if let Some(payload) = self.heartbeat.ping_due(now) {
+                                    if let Err(error) = self.protocol.encode_message(
+                                        &Message::Ping(payload),
+                                        &mut self.write_buf,
+                                    ) {
+                                        return Some(Err(error));
+                                    }
+                                    if let Err(error) = self.flush().await {
+                                        return Some(Err(error));
+                                    }
+                                    self.heartbeat.ping_flushed(
+                                        self.clock_epoch.elapsed().as_millis() as u64,
+                                    );
+                                }
+                                None
+                            }
+                            Some(Deadline::Pong(at)) if at <= now => {
+                                self.heartbeat.stop();
+                                self.state = CompioStreamState::CloseSent;
+                                let close = Message::Close(Some(CloseReason::new(
+                                    self.config.pong_timeout_close_code,
+                                    bounded_close_reason(&self.config.pong_timeout_close_reason),
+                                )));
+                                let _ = self.protocol.encode_message(&close, &mut self.write_buf);
+                                let _ = ::compio::time::timeout(
+                                    Duration::from_secs(self.config.close_timeout.into()),
+                                    self.flush(),
+                                )
+                                .await;
+                                self.state = CompioStreamState::Closed;
+                                return Some(Err(Error::HeartbeatTimeout));
+                            }
+                            Some(Deadline::Idle(at)) if at <= now => {
+                                self.heartbeat.stop();
+                                self.state = CompioStreamState::CloseSent;
+                                let close = Message::Close(Some(CloseReason::new(
+                                    CloseReason::GOING_AWAY,
+                                    "Connection idle timeout",
+                                )));
+                                let _ = self.protocol.encode_message(&close, &mut self.write_buf);
+                                let _ = ::compio::time::timeout(
+                                    Duration::from_secs(self.config.close_timeout.into()),
+                                    self.flush(),
+                                )
+                                .await;
+                                self.state = CompioStreamState::Closed;
+                                return Some(Err(Error::IdleTimeout));
+                            }
+                            _ => None,
+                        }
+                    }
+                }
+            } else {
+                Some(read_more(&mut self.inner, &mut self.read_buf).await)
+            };
+            let Some(read_result) = read_result else {
+                continue;
+            };
+            match read_result {
                 Ok(0) => {
+                    self.heartbeat.stop();
                     self.state = CompioStreamState::Closed;
                     return None;
                 }
                 Ok(_) => {}
-                Err(e) => return Some(Err(e.into())),
+                Err(e) => {
+                    self.heartbeat.stop();
+                    self.state = CompioStreamState::Closed;
+                    return Some(Err(e.into()));
+                }
             }
         }
     }
@@ -1656,10 +2305,16 @@ where
 
         if msg.is_close() {
             self.state = CompioStreamState::CloseSent;
+            self.heartbeat.stop();
         }
 
         self.protocol.encode_message(&msg, &mut self.write_buf)?;
-        self.flush().await
+        if let Err(error) = self.flush().await {
+            self.heartbeat.stop();
+            self.state = CompioStreamState::Closed;
+            return Err(error);
+        }
+        Ok(())
     }
 
     /// Send a text message.
@@ -1745,12 +2400,20 @@ where
         match &msg {
             Message::Ping(data) => {
                 self.protocol.encode_pong(data, &mut self.write_buf);
-                self.flush().await?;
+                if let Err(error) = self.flush().await {
+                    self.heartbeat.stop();
+                    self.state = CompioStreamState::Closed;
+                    return Err(error);
+                }
             }
             Message::Close(reason) => {
+                self.heartbeat.stop();
                 if self.state == CompioStreamState::Open {
                     self.protocol.encode_close_response(&mut self.write_buf);
-                    self.flush().await?;
+                    if let Err(error) = self.flush().await {
+                        self.state = CompioStreamState::Closed;
+                        return Err(error);
+                    }
                 }
                 self.state = CompioStreamState::Closed;
                 return Ok(Message::Close(reason.clone()));
@@ -1767,7 +2430,7 @@ impl<S> CompioCompressedWebSocketStream<S>
 where
     S: Splittable,
     S::ReadHalf: AsyncRead,
-    S::WriteHalf: AsyncWrite,
+    S::WriteHalf: AsyncWrite + 'static,
 {
     /// Split the compressed WebSocket stream into Compio read and write halves.
     pub fn split(
@@ -1777,10 +2440,28 @@ where
         CompioCompressedSplitWriter<S::WriteHalf>,
     ) {
         let (reader, writer) = Splittable::split(self.inner);
-        let (control_tx, control_rx) = mpsc::channel();
+        let (control_tx, control_rx) = mpsc::channel(SPLIT_CONTROL_CAPACITY);
+        let (application_tx, application_rx) = mpsc::channel(SPLIT_APPLICATION_CAPACITY);
+        let (cancel_tx, cancel_rx) = mpsc::unbounded();
+        let (terminal_tx, terminal_rx) = mpsc::unbounded();
+        let shared = CompioSplitShared::new(self.state != CompioStreamState::Open);
         let (reader_protocol, writer_protocol) = self
             .protocol
             .split(self.config.max_frame_size, self.config.max_message_size);
+
+        ::compio::runtime::spawn(compio_split_writer_driver(
+            writer,
+            writer_protocol,
+            self.config,
+            CompioDriverChannels {
+                control_rx,
+                application_rx,
+                cancel_rx,
+                terminal_tx,
+                shared: shared.clone(),
+            },
+        ))
+        .detach();
 
         (
             CompioCompressedSplitReader {
@@ -1790,14 +2471,16 @@ where
                 pending_messages: self.pending_messages,
                 pending_index: self.pending_index,
                 control_tx,
-                closed: self.state == CompioStreamState::Closed,
+                terminal_rx,
+                cancel_tx: cancel_tx.clone(),
+                shared: shared.clone(),
+                terminal_reported: false,
             },
             CompioCompressedSplitWriter {
-                writer,
-                protocol: writer_protocol,
-                write_buf: BytesMut::with_capacity(self.config.write_buffer_size),
-                control_rx,
-                closed: self.state == CompioStreamState::Closed,
+                application_tx,
+                cancel_tx,
+                shared,
+                _writer: PhantomData,
             },
         )
     }
@@ -1812,17 +2495,19 @@ pub struct CompioCompressedSplitReader<R> {
     pending_messages: Vec<Message>,
     pending_index: usize,
     control_tx: mpsc::Sender<ControlRequest>,
-    closed: bool,
+    terminal_rx: mpsc::UnboundedReceiver<CompioTerminalCause>,
+    cancel_tx: mpsc::UnboundedSender<()>,
+    shared: Rc<CompioSplitShared>,
+    terminal_reported: bool,
 }
 
 /// Write half of a split compressed Compio WebSocket stream.
 #[cfg(feature = "permessage-deflate")]
 pub struct CompioCompressedSplitWriter<W> {
-    writer: W,
-    protocol: CompressedWriterProtocol,
-    write_buf: BytesMut,
-    control_rx: mpsc::Receiver<ControlRequest>,
-    closed: bool,
+    application_tx: mpsc::Sender<ApplicationRequest>,
+    cancel_tx: mpsc::UnboundedSender<()>,
+    shared: Rc<CompioSplitShared>,
+    _writer: PhantomData<fn() -> W>,
 }
 
 #[cfg(feature = "permessage-deflate")]
@@ -1833,8 +2518,18 @@ where
     /// Receive the next non-control message.
     pub async fn next(&mut self) -> Option<Result<Message>> {
         loop {
-            if self.closed {
-                return None;
+            if self.shared.status.get() == SPLIT_CLOSED {
+                if self.terminal_reported {
+                    return None;
+                }
+                self.terminal_reported = true;
+                return match self.shared.terminal.get() {
+                    Some(CompioTerminalCause::HeartbeatTimeout) => {
+                        Some(Err(Error::HeartbeatTimeout))
+                    }
+                    Some(CompioTerminalCause::IdleTimeout) => Some(Err(Error::IdleTimeout)),
+                    _ => None,
+                };
             }
 
             if self.pending_index < self.pending_messages.len() {
@@ -1846,21 +2541,20 @@ where
                     self.pending_index = 0;
                 }
 
-                match &msg {
-                    Message::Ping(data) => {
-                        let _ = self.control_tx.send(ControlRequest::Pong(data.clone()));
-                        continue;
+                let request = match &msg {
+                    Message::Ping(data) => ControlRequest::PeerPing(data.clone(), Instant::now()),
+                    Message::Pong(data) => ControlRequest::Pong(data.clone(), Instant::now()),
+                    Message::Close(_) => {
+                        self.shared.begin_closing();
+                        ControlRequest::PeerClose
                     }
-                    Message::Close(reason) => {
-                        if !self.closed {
-                            let _ = self.control_tx.send(ControlRequest::CloseResponse);
-                            self.closed = true;
-                        }
-                        return Some(Ok(Message::Close(reason.clone())));
-                    }
-                    Message::Pong(_) => continue,
-                    _ => return Some(Ok(msg)),
+                    _ => ControlRequest::Activity(Instant::now()),
+                };
+                if self.control_tx.send(request).await.is_err() {
+                    self.shared.terminate(CompioTerminalCause::ConnectionClosed);
+                    continue;
                 }
+                return Some(Ok(msg));
             }
 
             if !self.read_buf.is_empty() {
@@ -1871,46 +2565,69 @@ where
                         continue;
                     }
                     Ok(_) => {}
-                    Err(e) => return Some(Err(e)),
+                    Err(e) => {
+                        self.shared.terminate(CompioTerminalCause::ConnectionClosed);
+                        return Some(Err(e));
+                    }
                 }
             }
 
-            match read_more(&mut self.reader, &mut self.read_buf).await {
-                Ok(0) => {
-                    self.closed = true;
-                    return None;
+            let outcome = {
+                let read = read_more(&mut self.reader, &mut self.read_buf).fuse();
+                let terminal = self.terminal_rx.next().fuse();
+                futures_util::pin_mut!(read, terminal);
+                futures_util::select_biased! {
+                    cause = terminal => CompioReadOutcome::Terminal(cause),
+                    result = read => CompioReadOutcome::Read(result),
                 }
-                Ok(_) => {}
-                Err(e) => return Some(Err(e.into())),
+            };
+            match outcome {
+                CompioReadOutcome::Read(Ok(0)) => {
+                    let _ = self.control_tx.send(ControlRequest::Eof).await;
+                    self.shared.terminate(CompioTerminalCause::ConnectionClosed);
+                }
+                CompioReadOutcome::Read(Ok(_)) => {}
+                CompioReadOutcome::Read(Err(error)) => {
+                    self.shared.terminate(CompioTerminalCause::ConnectionClosed);
+                    return Some(Err(error.into()));
+                }
+                CompioReadOutcome::Terminal(cause) => {
+                    if let Some(cause) = cause {
+                        self.shared.terminate(cause);
+                    } else {
+                        self.shared.terminate(CompioTerminalCause::ConnectionClosed);
+                    }
+                }
             }
         }
     }
 
     /// Check whether the reader is closed.
     pub fn is_closed(&self) -> bool {
-        self.closed
+        !self.shared.is_open()
     }
 }
 
 #[cfg(feature = "permessage-deflate")]
-impl<W> CompioCompressedSplitWriter<W>
-where
-    W: AsyncWrite,
-{
+impl<R> Drop for CompioCompressedSplitReader<R> {
+    fn drop(&mut self) {
+        let _ = self.cancel_tx.unbounded_send(());
+    }
+}
+
+#[cfg(feature = "permessage-deflate")]
+impl<W> CompioCompressedSplitWriter<W> {
     /// Send a WebSocket message.
     pub async fn send(&mut self, msg: Message) -> Result<()> {
-        if self.closed {
-            return Err(Error::ConnectionClosed);
+        if !self.shared.is_open() {
+            return Err(self.current_error());
         }
-
-        self.process_control_requests().await?;
-
-        if msg.is_close() {
-            self.closed = true;
-        }
-
-        self.protocol.encode_message(&msg, &mut self.write_buf)?;
-        self.flush().await
+        let (tx, rx) = oneshot::channel();
+        self.application_tx
+            .send(ApplicationRequest::Send(msg, tx))
+            .await
+            .map_err(|_| self.current_error())?;
+        rx.await.map_err(|_| self.current_error())?
     }
 
     /// Send a text message.
@@ -1931,33 +2648,34 @@ where
 
     /// Flush pending data and control responses.
     pub async fn flush(&mut self) -> Result<()> {
-        self.process_control_requests().await?;
-        flush_bytes(&mut self.writer, &mut self.write_buf).await
+        if !self.shared.is_open() {
+            return Err(self.current_error());
+        }
+        let (tx, rx) = oneshot::channel();
+        self.application_tx
+            .send(ApplicationRequest::Flush(tx))
+            .await
+            .map_err(|_| self.current_error())?;
+        rx.await.map_err(|_| self.current_error())?
     }
 
     /// Check whether the writer is closed.
     pub fn is_closed(&self) -> bool {
-        self.closed
+        !self.shared.is_open()
     }
 
-    async fn process_control_requests(&mut self) -> Result<()> {
-        while let Ok(req) = self.control_rx.try_recv() {
-            match req {
-                ControlRequest::Pong(data) => {
-                    self.protocol.encode_pong(&data, &mut self.write_buf);
-                }
-                ControlRequest::CloseResponse => {
-                    self.protocol.encode_close_response(&mut self.write_buf);
-                    self.closed = true;
-                }
-            }
-        }
+    fn current_error(&self) -> Error {
+        self.shared
+            .terminal
+            .get()
+            .map_or(Error::ConnectionClosed, CompioTerminalCause::error)
+    }
+}
 
-        if !self.write_buf.is_empty() {
-            flush_bytes(&mut self.writer, &mut self.write_buf).await?;
-        }
-
-        Ok(())
+#[cfg(feature = "permessage-deflate")]
+impl<W> Drop for CompioCompressedSplitWriter<W> {
+    fn drop(&mut self) {
+        let _ = self.cancel_tx.unbounded_send(());
     }
 }
 
@@ -2030,6 +2748,41 @@ mod tests {
         let echoed = client.next().await.unwrap().unwrap();
         assert!(matches!(echoed, Message::Binary(bytes) if bytes.as_ref() == b"payload"));
 
+        server.await.unwrap();
+    }
+
+    #[compio::test]
+    async fn compio_split_driver_replies_to_ping_without_application_write() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = ::compio::runtime::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let config = Config::builder().auto_ping(false).idle_timeout(0).build();
+            let (ws, _) = accept_async(stream, config).await.unwrap();
+            let (mut reader, _writer) = ws.split();
+
+            assert!(matches!(
+                reader.next().await,
+                Some(Ok(Message::Ping(payload))) if payload == b"pin"[..]
+            ));
+            assert!(matches!(reader.next().await, Some(Ok(Message::Close(_)))));
+        });
+
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let config = Config::builder().auto_ping(false).idle_timeout(0).build();
+        let (mut client, _) = connect_async(stream, &addr.to_string(), "/", None, config)
+            .await
+            .unwrap();
+        client
+            .send(Message::Ping(Bytes::from_static(b"pin")))
+            .await
+            .unwrap();
+        assert!(matches!(
+            client.next().await,
+            Some(Ok(Message::Pong(payload))) if payload == b"pin"[..]
+        ));
+        client.close(1000, "").await.unwrap();
         server.await.unwrap();
     }
 
@@ -2269,6 +3022,41 @@ mod tests {
         let echoed = client.next().await.unwrap().unwrap();
         assert!(matches!(echoed, Message::Text(text) if text == "compressed"));
 
+        server.await.unwrap();
+    }
+
+    #[cfg(feature = "permessage-deflate")]
+    #[compio::test]
+    async fn compio_compressed_split_driver_replies_to_ping() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server = ::compio::runtime::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let config = Config::builder().auto_ping(false).idle_timeout(0).build();
+            let ws =
+                CompioCompressedWebSocketStream::server(stream, config, DeflateConfig::default());
+            let (mut reader, _writer) = ws.split();
+            assert!(matches!(
+                reader.next().await,
+                Some(Ok(Message::Ping(payload))) if payload == b"pin"[..]
+            ));
+            assert!(matches!(reader.next().await, Some(Ok(Message::Close(_)))));
+        });
+
+        let stream = TcpStream::connect(addr).await.unwrap();
+        let config = Config::builder().auto_ping(false).idle_timeout(0).build();
+        let mut client =
+            CompioCompressedWebSocketStream::client(stream, config, DeflateConfig::default());
+        client
+            .send(Message::Ping(Bytes::from_static(b"pin")))
+            .await
+            .unwrap();
+        assert!(matches!(
+            client.next().await,
+            Some(Ok(Message::Pong(payload))) if payload == b"pin"[..]
+        ));
+        client.close(1000, "").await.unwrap();
         server.await.unwrap();
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,10 @@ pub enum Error {
     Capacity(&'static str),
     /// Compression/decompression error
     Compression(String),
+    /// The matching Pong for a native keepalive Ping was not received in time.
+    HeartbeatTimeout,
+    /// No valid inbound frame was received before the configured hard idle deadline.
+    IdleTimeout,
 
     // ========================================================================
     // Transport-specific errors
@@ -165,6 +169,7 @@ impl Error {
             Error::InvalidCloseCode(_) => ErrorKind::Validation,
             Error::Capacity(_) => ErrorKind::Capacity,
             Error::Compression(_) => ErrorKind::Compression,
+            Error::HeartbeatTimeout | Error::IdleTimeout => ErrorKind::Connection,
             #[cfg(feature = "http2")]
             Error::Http2(_) => ErrorKind::Transport,
             #[cfg(feature = "http3")]
@@ -194,6 +199,8 @@ impl Error {
                 | Error::MessageTooLarge
                 | Error::StreamReset
                 | Error::InvalidCloseCode(_)
+                | Error::HeartbeatTimeout
+                | Error::IdleTimeout
         )
     }
 
@@ -211,10 +218,8 @@ impl Error {
     /// `tokio::time::timeout`, but some transport errors may indicate timeouts.
     #[inline]
     pub fn is_timeout(&self) -> bool {
-        if let Error::Io(e) = self {
-            return e.kind() == io::ErrorKind::TimedOut;
-        }
-        false
+        matches!(self, Error::HeartbeatTimeout | Error::IdleTimeout)
+            || matches!(self, Error::Io(e) if e.kind() == io::ErrorKind::TimedOut)
     }
 
     /// Check if this error is a connection error
@@ -252,6 +257,8 @@ impl Error {
             Error::InvalidCloseCode(_) => "invalid_close_code",
             Error::Capacity(_) => "capacity_exceeded",
             Error::Compression(_) => "compression_error",
+            Error::HeartbeatTimeout => "heartbeat_timeout",
+            Error::IdleTimeout => "idle_timeout",
             #[cfg(feature = "http2")]
             Error::Http2(_) => "http2_error",
             #[cfg(feature = "http3")]
@@ -308,6 +315,8 @@ impl fmt::Display for Error {
             Error::InvalidCloseCode(code) => write!(f, "Invalid close code: {}", code),
             Error::Capacity(msg) => write!(f, "Capacity exceeded: {}", msg),
             Error::Compression(msg) => write!(f, "Compression error: {}", msg),
+            Error::HeartbeatTimeout => write!(f, "WebSocket Pong deadline expired"),
+            Error::IdleTimeout => write!(f, "WebSocket inbound idle deadline expired"),
             #[cfg(feature = "http2")]
             Error::Http2(e) => write!(f, "HTTP/2 error: {}", e),
             #[cfg(feature = "http3")]

--- a/src/heartbeat.rs
+++ b/src/heartbeat.rs
@@ -1,0 +1,263 @@
+//! Runtime-neutral native WebSocket heartbeat state.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use bytes::Bytes;
+
+use crate::Config;
+
+static NEXT_NONCE: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Deadline {
+    Pong(u64),
+    Idle(u64),
+    Ping(u64),
+}
+
+impl Deadline {
+    pub(crate) fn at(self) -> u64 {
+        match self {
+            Self::Pong(at) | Self::Idle(at) | Self::Ping(at) => at,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Heartbeat {
+    auto_ping: bool,
+    ping_interval_ms: u64,
+    idle_timeout_ms: u64,
+    pong_timeout_ms: u64,
+    last_inbound_ms: u64,
+    outstanding: Option<OutstandingPing>,
+    stopped: bool,
+}
+
+#[derive(Debug)]
+struct OutstandingPing {
+    payload: Bytes,
+    deadline_ms: Option<u64>,
+    flushed: bool,
+}
+
+impl Heartbeat {
+    pub(crate) fn new(config: &Config, now_ms: u64) -> Self {
+        Self {
+            auto_ping: config.auto_ping && config.ping_interval != 0,
+            ping_interval_ms: seconds_ms(config.ping_interval),
+            idle_timeout_ms: seconds_ms(config.idle_timeout),
+            pong_timeout_ms: seconds_ms(config.pong_timeout),
+            last_inbound_ms: now_ms,
+            outstanding: None,
+            stopped: false,
+        }
+    }
+
+    pub(crate) fn next_deadline(&self) -> Option<Deadline> {
+        if self.stopped {
+            return None;
+        }
+
+        // A Pong timeout deliberately wins ties with the hard idle timeout.
+        if let Some(deadline) = self.outstanding.as_ref().and_then(|ping| ping.deadline_ms) {
+            return Some(Deadline::Pong(deadline));
+        }
+
+        let idle = (self.idle_timeout_ms != 0)
+            .then(|| self.last_inbound_ms.saturating_add(self.idle_timeout_ms));
+        let ping = (self.auto_ping && self.outstanding.is_none())
+            .then(|| self.last_inbound_ms.saturating_add(self.ping_interval_ms));
+
+        match (idle, ping) {
+            (Some(idle), Some(ping)) if idle <= ping => Some(Deadline::Idle(idle)),
+            (Some(_), Some(ping)) => Some(Deadline::Ping(ping)),
+            (Some(idle), None) => Some(Deadline::Idle(idle)),
+            (None, Some(ping)) => Some(Deadline::Ping(ping)),
+            (None, None) => None,
+        }
+    }
+
+    pub(crate) fn ping_due(&mut self, now_ms: u64) -> Option<Bytes> {
+        if !matches!(self.next_deadline(), Some(Deadline::Ping(at)) if at <= now_ms) {
+            return None;
+        }
+
+        let nonce = NEXT_NONCE.fetch_add(1, Ordering::Relaxed);
+        let payload = Bytes::copy_from_slice(&nonce.to_be_bytes());
+        self.outstanding = Some(OutstandingPing {
+            payload: payload.clone(),
+            deadline_ms: None,
+            flushed: false,
+        });
+        Some(payload)
+    }
+
+    pub(crate) fn ping_flushed(&mut self, now_ms: u64) {
+        if let Some(ping) = &mut self.outstanding
+            && !ping.flushed
+        {
+            ping.flushed = true;
+            ping.deadline_ms =
+                (self.pong_timeout_ms != 0).then(|| now_ms.saturating_add(self.pong_timeout_ms));
+        }
+    }
+
+    /// Record a decoded inbound frame.
+    ///
+    /// Every valid inbound frame resets inactivity. Only the exact Pong for the
+    /// currently outstanding, successfully flushed Ping clears its deadline.
+    pub(crate) fn on_inbound(&mut self, now_ms: u64, pong: Option<&Bytes>) -> bool {
+        if self.stopped {
+            return false;
+        }
+
+        self.last_inbound_ms = now_ms;
+        let matched = self.outstanding.as_ref().is_some_and(|ping| {
+            ping.flushed
+                && ping.deadline_ms.is_none_or(|deadline| now_ms < deadline)
+                && pong.is_some_and(|payload| payload == &ping.payload)
+        });
+        if matched {
+            self.outstanding = None;
+        }
+        matched
+    }
+
+    pub(crate) fn stop(&mut self) {
+        self.stopped = true;
+        self.outstanding = None;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn has_outstanding_ping(&self) -> bool {
+        self.outstanding.is_some()
+    }
+}
+
+fn seconds_ms(seconds: u32) -> u64 {
+    Duration::from_secs(seconds.into()).as_millis() as u64
+}
+
+pub(crate) fn bounded_close_reason(reason: &str) -> String {
+    const MAX_REASON_BYTES: usize = 123;
+    if reason.len() <= MAX_REASON_BYTES {
+        return reason.to_owned();
+    }
+
+    let mut end = MAX_REASON_BYTES;
+    while !reason.is_char_boundary(end) {
+        end -= 1;
+    }
+    reason[..end].to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config() -> Config {
+        Config::builder()
+            .idle_timeout(0)
+            .ping_interval(10)
+            .pong_timeout(5)
+            .build()
+    }
+
+    #[test]
+    fn inactivity_and_matching_pong_cycle() {
+        let mut heartbeat = Heartbeat::new(&config(), 0);
+        assert_eq!(heartbeat.next_deadline(), Some(Deadline::Ping(10_000)));
+        assert!(heartbeat.ping_due(9_999).is_none());
+
+        let payload = heartbeat.ping_due(10_000).unwrap();
+        assert!(heartbeat.has_outstanding_ping());
+        assert_eq!(heartbeat.next_deadline(), None);
+
+        heartbeat.ping_flushed(10_100);
+        assert_eq!(heartbeat.next_deadline(), Some(Deadline::Pong(15_100)));
+        assert!(!heartbeat.on_inbound(11_000, Some(&Bytes::from_static(b"wrong"))));
+        assert_eq!(heartbeat.next_deadline(), Some(Deadline::Pong(15_100)));
+        assert!(heartbeat.on_inbound(12_000, Some(&payload)));
+        assert_eq!(heartbeat.next_deadline(), Some(Deadline::Ping(22_000)));
+    }
+
+    #[test]
+    fn traffic_resets_inactivity_but_not_pong_deadline() {
+        let mut heartbeat = Heartbeat::new(&config(), 0);
+        let _ = heartbeat.ping_due(10_000).unwrap();
+        heartbeat.ping_flushed(10_000);
+        heartbeat.on_inbound(12_000, None);
+        assert_eq!(heartbeat.next_deadline(), Some(Deadline::Pong(15_000)));
+    }
+
+    #[test]
+    fn zero_pong_timeout_keeps_one_ping_outstanding_without_deadline() {
+        let config = Config::builder()
+            .idle_timeout(0)
+            .ping_interval(1)
+            .pong_timeout(0)
+            .build();
+        let mut heartbeat = Heartbeat::new(&config, 0);
+        let _ = heartbeat.ping_due(1_000).unwrap();
+        heartbeat.ping_flushed(1_000);
+        assert_eq!(heartbeat.next_deadline(), None);
+        assert!(heartbeat.has_outstanding_ping());
+    }
+
+    #[test]
+    fn pong_timeout_wins_idle_timeout_tie() {
+        let config = Config::builder()
+            .ping_interval(1)
+            .pong_timeout(2)
+            .idle_timeout(3)
+            .build();
+        let mut heartbeat = Heartbeat::new(&config, 0);
+        let _ = heartbeat.ping_due(1_000).unwrap();
+        heartbeat.ping_flushed(1_000);
+        assert_eq!(heartbeat.next_deadline(), Some(Deadline::Pong(3_000)));
+    }
+
+    #[test]
+    fn close_reason_is_bounded_at_a_utf8_boundary() {
+        let reason = "x".repeat(122) + "€";
+        let bounded = bounded_close_reason(&reason);
+        assert_eq!(bounded.len(), 122);
+        assert!(bounded.is_char_boundary(bounded.len()));
+    }
+
+    #[test]
+    fn unsolicited_stale_and_late_pongs_do_not_match() {
+        let mut heartbeat = Heartbeat::new(&config(), 0);
+        assert!(!heartbeat.on_inbound(1_000, Some(&Bytes::from_static(b"unsolicited"))));
+
+        let first = heartbeat.ping_due(11_000).unwrap();
+        heartbeat.ping_flushed(11_000);
+        assert!(heartbeat.on_inbound(12_000, Some(&first)));
+
+        let second = heartbeat.ping_due(22_000).unwrap();
+        heartbeat.ping_flushed(22_000);
+        assert_ne!(first, second);
+        assert!(!heartbeat.on_inbound(23_000, Some(&first)));
+        assert!(!heartbeat.on_inbound(27_000, Some(&second)));
+        assert!(heartbeat.has_outstanding_ping());
+    }
+
+    #[test]
+    fn disabled_proactive_ping_and_zero_hard_idle_have_no_deadline() {
+        let config = Config::builder()
+            .auto_ping(false)
+            .ping_interval(1)
+            .idle_timeout(0)
+            .build();
+        assert_eq!(Heartbeat::new(&config, 0).next_deadline(), None);
+
+        let zero_interval = Config::builder()
+            .auto_ping(true)
+            .ping_interval(0)
+            .idle_timeout(0)
+            .build();
+        assert_eq!(Heartbeat::new(&zero_interval, 0).next_deadline(), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ pub mod cork;
 pub mod error;
 pub mod frame;
 pub mod handshake;
+mod heartbeat;
 pub mod mask;
 pub mod protocol;
 #[cfg(feature = "tokio-runtime")]
@@ -435,16 +436,31 @@ pub struct Config {
     pub write_buffer_size: usize,
     /// Compression mode (default: Disabled)
     pub compression: Compression,
-    /// Idle timeout in seconds (default: 120, 0 = disabled)
-    /// Connection is closed if no data received within this time
+    /// Hard inbound-idle timeout in seconds (default: 120, 0 = disabled).
+    ///
+    /// Every valid inbound frame resets this independent deadline. When it
+    /// ties a Pong deadline, the more specific Pong timeout wins.
     pub idle_timeout: u32,
     /// Maximum backpressure in bytes before dropping connection (default: 1MB)
     /// If write buffer exceeds this, connection is closed
     pub max_backpressure: usize,
-    /// Send pings automatically to keep connection alive (default: true)
+    /// Send native Pings after inbound inactivity (default: true).
+    ///
+    /// Disabling this does not disable mandatory automatic Pong or Close
+    /// responses.
     pub auto_ping: bool,
-    /// Ping interval in seconds (default: 30)
+    /// Inbound inactivity before a native Ping (default: 30, 0 = disabled).
     pub ping_interval: u32,
+    /// Time to wait for the matching Pong after a native Ping is flushed
+    /// (default: 10 seconds, 0 = no Pong deadline).
+    pub pong_timeout: u32,
+    /// Close code used when a native Pong deadline expires (default: 1001).
+    pub pong_timeout_close_code: u16,
+    /// Close reason used when a native Pong deadline expires.
+    pub pong_timeout_close_reason: String,
+    /// Maximum time spent flushing a timeout/handshake Close and shutting down
+    /// the transport (default: 5 seconds, 0 = immediate best effort).
+    pub close_timeout: u32,
     /// Per-message deflate configuration (requires `permessage-deflate` feature)
     #[cfg(feature = "permessage-deflate")]
     pub deflate: Option<crate::deflate::DeflateConfig>,
@@ -472,6 +488,10 @@ impl Default for Config {
             max_backpressure: 1024 * 1024,
             auto_ping: true,
             ping_interval: 30,
+            pong_timeout: 10,
+            pong_timeout_close_code: crate::error::CloseReason::GOING_AWAY,
+            pong_timeout_close_reason: "Pong reply not received in time".to_string(),
+            close_timeout: 5,
             #[cfg(feature = "permessage-deflate")]
             deflate: None,
             #[cfg(feature = "http2")]
@@ -497,10 +517,17 @@ impl Config {
             max_frame_size: 16 * 1024,
             write_buffer_size: CORK_BUFFER_SIZE,
             compression: Compression::Shared,
-            idle_timeout: 10,
+            // A hard inbound-idle deadline shorter than the first Ping is
+            // surprising. uWS-style defaults therefore leave hard idle
+            // detection disabled and use correlated Ping/Pong detection.
+            idle_timeout: 0,
             max_backpressure: 1024 * 1024,
             auto_ping: true,
             ping_interval: 30,
+            pong_timeout: 10,
+            pong_timeout_close_code: crate::error::CloseReason::GOING_AWAY,
+            pong_timeout_close_reason: "Pong reply not received in time".to_string(),
+            close_timeout: 5,
             #[cfg(feature = "permessage-deflate")]
             deflate: None,
             #[cfg(feature = "http2")]
@@ -580,6 +607,30 @@ impl ConfigBuilder {
     /// Set ping interval in seconds
     pub fn ping_interval(mut self, seconds: u32) -> Self {
         self.config.ping_interval = seconds;
+        self
+    }
+
+    /// Set the matching Pong deadline in seconds.
+    ///
+    /// A value of 0 disables the deadline. The connection still keeps exactly
+    /// one Ping outstanding until its matching Pong arrives.
+    pub fn pong_timeout(mut self, seconds: u32) -> Self {
+        self.config.pong_timeout = seconds;
+        self
+    }
+
+    /// Set the Close code and reason used when the Pong deadline expires.
+    ///
+    /// The reason is truncated to the RFC 6455 control-frame limit when encoded.
+    pub fn pong_timeout_close(mut self, code: u16, reason: impl Into<String>) -> Self {
+        self.config.pong_timeout_close_code = code;
+        self.config.pong_timeout_close_reason = reason.into();
+        self
+    }
+
+    /// Set the bounded Close flush/shutdown deadline in seconds.
+    pub fn close_timeout(mut self, seconds: u32) -> Self {
+        self.config.close_timeout = seconds;
         self
     }
 

--- a/src/stream/websocket.rs
+++ b/src/stream/websocket.rs
@@ -16,6 +16,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use crate::Config;
 use crate::cork::CorkBuffer;
 use crate::error::{CloseReason, Error, Result};
+use crate::heartbeat::{Deadline, Heartbeat, bounded_close_reason};
 use crate::protocol::{Message, Protocol, Role};
 
 /// Default high water mark for backpressure (64KB)
@@ -71,10 +72,13 @@ pin_project! {
         pending_index: usize,
         // A control message is only returned after its automatic response is flushed.
         pending_control_message: Option<Message>,
+        pending_terminal_error: Option<Error>,
         flush_on_read: bool,
         close_after_flush: bool,
-        // Created lazily from poll_next so construction does not require a Tokio runtime.
-        auto_ping_sleep: Option<Pin<Box<tokio::time::Sleep>>>,
+        ping_flush_pending: bool,
+        clock_epoch: tokio::time::Instant,
+        heartbeat: Heartbeat,
+        heartbeat_sleep: Option<Pin<Box<tokio::time::Sleep>>>,
         // Backpressure thresholds
         high_water_mark: usize,
         low_water_mark: usize,
@@ -100,6 +104,8 @@ where
     /// Create a new WebSocket stream from an already-upgraded connection
     pub fn from_raw(inner: S, role: Role, config: Config) -> Self {
         let protocol = Protocol::new(role, config.max_frame_size, config.max_message_size);
+        let clock_epoch = tokio::time::Instant::now();
+        let heartbeat = Heartbeat::new(&config, 0);
 
         Self {
             inner,
@@ -111,9 +117,13 @@ where
             pending_messages: Vec::new(),
             pending_index: 0,
             pending_control_message: None,
+            pending_terminal_error: None,
             flush_on_read: false,
             close_after_flush: false,
-            auto_ping_sleep: None,
+            ping_flush_pending: false,
+            clock_epoch,
+            heartbeat,
+            heartbeat_sleep: None,
             high_water_mark: DEFAULT_HIGH_WATER_MARK,
             low_water_mark: DEFAULT_LOW_WATER_MARK,
         }
@@ -360,17 +370,32 @@ where
                     Poll::Ready(Ok(())) => {
                         let this = self.as_mut().get_mut();
                         this.flush_on_read = false;
+                        if this.ping_flush_pending {
+                            this.ping_flush_pending = false;
+                            let now = this.clock_epoch.elapsed().as_millis() as u64;
+                            this.heartbeat.ping_flushed(now);
+                            this.heartbeat_sleep = None;
+                        }
 
                         if this.close_after_flush {
                             this.close_after_flush = false;
                             this.state = StreamState::Closed;
                         }
 
+                        if let Some(error) = this.pending_terminal_error.take() {
+                            return Poll::Ready(Some(Err(error)));
+                        }
                         if let Some(msg) = this.pending_control_message.take() {
                             return Poll::Ready(Some(Ok(msg)));
                         }
                     }
-                    Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
+                    Poll::Ready(Err(e)) => {
+                        let this = self.as_mut().get_mut();
+                        this.state = StreamState::Closed;
+                        this.heartbeat.stop();
+                        this.heartbeat_sleep = None;
+                        return Poll::Ready(Some(Err(e)));
+                    }
                     Poll::Pending => return Poll::Pending,
                 }
             }
@@ -380,29 +405,85 @@ where
                 return Poll::Ready(None);
             }
 
-            // Register a timer wakeup and send a Ping even when the peer is silent.
-            if self.config.auto_ping && self.config.ping_interval > 0 {
-                let interval = Duration::from_secs(self.config.ping_interval.into());
-                let this = self.as_mut().get_mut();
-                let sleep = this
-                    .auto_ping_sleep
-                    .get_or_insert_with(|| Box::pin(tokio::time::sleep(interval)));
-
-                if sleep.as_mut().poll(cx).is_ready() {
-                    this.auto_ping_sleep = Some(Box::pin(tokio::time::sleep(interval)));
-                    if let Err(e) = this
-                        .protocol
-                        .encode_message(&Message::Ping(Bytes::new()), this.write_buf.buffer_mut())
-                    {
-                        return Poll::Ready(Some(Err(e)));
+            // Heartbeat deadlines are based on inbound inactivity. A Pong
+            // deadline starts only after the corresponding Ping is flushed.
+            let deadline = self.heartbeat.next_deadline();
+            if let Some(deadline) = deadline {
+                let now = self.clock_epoch.elapsed().as_millis() as u64;
+                if deadline.at() <= now {
+                    let this = self.as_mut().get_mut();
+                    match deadline {
+                        Deadline::Ping(_) => {
+                            if let Some(payload) = this.heartbeat.ping_due(now) {
+                                if let Err(e) = this.protocol.encode_message(
+                                    &Message::Ping(payload),
+                                    this.write_buf.buffer_mut(),
+                                ) {
+                                    this.state = StreamState::Closed;
+                                    this.heartbeat.stop();
+                                    return Poll::Ready(Some(Err(e)));
+                                }
+                                this.ping_flush_pending = true;
+                                this.flush_on_read = true;
+                            }
+                        }
+                        Deadline::Pong(_) | Deadline::Idle(_) => {
+                            let (code, reason, error) = match deadline {
+                                Deadline::Pong(_) => (
+                                    this.config.pong_timeout_close_code,
+                                    bounded_close_reason(&this.config.pong_timeout_close_reason),
+                                    Error::HeartbeatTimeout,
+                                ),
+                                Deadline::Idle(_) => (
+                                    CloseReason::GOING_AWAY,
+                                    "Connection idle timeout".to_string(),
+                                    Error::IdleTimeout,
+                                ),
+                                Deadline::Ping(_) => unreachable!(),
+                            };
+                            let close = Message::Close(Some(CloseReason::new(code, reason)));
+                            if let Err(e) = this
+                                .protocol
+                                .encode_message(&close, this.write_buf.buffer_mut())
+                            {
+                                this.state = StreamState::Closed;
+                                this.heartbeat.stop();
+                                return Poll::Ready(Some(Err(e)));
+                            }
+                            this.heartbeat.stop();
+                            this.state = StreamState::CloseSent;
+                            this.pending_terminal_error = Some(error);
+                            this.flush_on_read = true;
+                            this.close_after_flush = true;
+                        }
                     }
-                    this.flush_on_read = true;
+                    this.heartbeat_sleep = None;
+                    continue;
+                }
+
+                let delay = Duration::from_millis(deadline.at().saturating_sub(now));
+                let sleep = self
+                    .as_mut()
+                    .get_mut()
+                    .heartbeat_sleep
+                    .get_or_insert_with(|| Box::pin(tokio::time::sleep(delay)));
+                if sleep.as_mut().poll(cx).is_ready() {
+                    self.as_mut().get_mut().heartbeat_sleep = None;
                     continue;
                 }
             }
 
             // First, return any pending messages
             if let Some(msg) = self.as_mut().get_mut().next_pending_message() {
+                let this = self.as_mut().get_mut();
+                let now = this.clock_epoch.elapsed().as_millis() as u64;
+                let pong = match &msg {
+                    Message::Pong(payload) => Some(payload),
+                    _ => None,
+                };
+                this.heartbeat.on_inbound(now, pong);
+                this.heartbeat_sleep = None;
+
                 // Handle control frames
                 match &msg {
                     Message::Ping(data) => {
@@ -415,6 +496,8 @@ where
                     }
                     Message::Close(reason) => {
                         let this = self.as_mut().get_mut();
+                        this.heartbeat.stop();
+                        this.heartbeat_sleep = None;
                         if this.state == StreamState::Open {
                             // Send close response
                             this.protocol
@@ -436,16 +519,27 @@ where
                 Poll::Ready(Ok(0)) => {
                     // EOF - connection closed
                     self.as_mut().get_mut().state = StreamState::Closed;
+                    self.as_mut().get_mut().heartbeat.stop();
                     return Poll::Ready(None);
                 }
                 Poll::Ready(Ok(_n)) => {
                     // Process the new data
                     match self.as_mut().get_mut().process_read_buf() {
                         Ok(()) => continue, // Loop to check for messages
-                        Err(e) => return Poll::Ready(Some(Err(e))),
+                        Err(e) => {
+                            let this = self.as_mut().get_mut();
+                            this.state = StreamState::Closed;
+                            this.heartbeat.stop();
+                            this.heartbeat_sleep = None;
+                            return Poll::Ready(Some(Err(e)));
+                        }
                     }
                 }
                 Poll::Ready(Err(e)) => {
+                    let this = self.as_mut().get_mut();
+                    this.state = StreamState::Closed;
+                    this.heartbeat.stop();
+                    this.heartbeat_sleep = None;
                     return Poll::Ready(Some(Err(e.into())));
                 }
                 Poll::Pending => {
@@ -464,7 +558,7 @@ where
     type Error = Error;
 
     fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
-        if self.state == StreamState::Closed {
+        if self.state != StreamState::Open {
             return Poll::Ready(Err(Error::ConnectionClosed));
         }
         Poll::Ready(Ok(()))
@@ -473,13 +567,15 @@ where
     fn start_send(self: Pin<&mut Self>, item: Message) -> Result<()> {
         let this = self.get_mut();
 
-        if this.state == StreamState::Closed {
+        if this.state != StreamState::Open {
             return Err(Error::ConnectionClosed);
         }
 
         // Track close frame sending
         if item.is_close() {
             this.state = StreamState::CloseSent;
+            this.heartbeat.stop();
+            this.heartbeat_sleep = None;
         }
 
         // Encode message into write buffer
@@ -500,12 +596,18 @@ where
 
             match Pin::new(&mut this.inner).poll_write_vectored(cx, &slices) {
                 Poll::Ready(Ok(0)) => {
+                    this.state = StreamState::Closed;
+                    this.heartbeat.stop();
+                    this.heartbeat_sleep = None;
                     return Poll::Ready(Err(Error::ConnectionClosed));
                 }
                 Poll::Ready(Ok(n)) => {
                     this.write_buf.consume(n);
                 }
                 Poll::Ready(Err(e)) => {
+                    this.state = StreamState::Closed;
+                    this.heartbeat.stop();
+                    this.heartbeat_sleep = None;
                     return Poll::Ready(Err(e.into()));
                 }
                 Poll::Pending => {
@@ -515,9 +617,15 @@ where
         }
 
         // Flush underlying stream
-        match Pin::new(&mut self.as_mut().get_mut().inner).poll_flush(cx) {
+        let this = self.as_mut().get_mut();
+        match Pin::new(&mut this.inner).poll_flush(cx) {
             Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+            Poll::Ready(Err(e)) => {
+                this.state = StreamState::Closed;
+                this.heartbeat.stop();
+                this.heartbeat_sleep = None;
+                Poll::Ready(Err(e.into()))
+            }
             Poll::Pending => Poll::Pending,
         }
     }
@@ -630,109 +738,167 @@ impl Default for WebSocketStreamBuilder {
 }
 
 // ============================================================================
-// Split Stream Implementation - LOCK-FREE EDITION 🚀
+// Split stream implementation
 // ============================================================================
 //
-// This implementation uses tokio::io::split() for true concurrent I/O:
-// - ✅ Zero mutex contention
-// - ✅ Reader and writer operate 100% independently
-// - ✅ Native OS-level efficiency
-// - ✅ No shared lock on the underlying transport
-//
-// Control frames (Ping/Pong/Close) are coordinated via an mpsc channel
-// from the reader to the writer, allowing the reader to request responses
-// without blocking.
+// One background driver owns the transport writer. Both application writes and
+// RFC control work use bounded queues; this is what lets Ping/Pong/Close make
+// progress when the application performs zero writes.
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf};
-use tokio::sync::mpsc;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, Ordering};
 
-/// Control frame requests sent from reader to writer
-#[derive(Debug, Clone)]
-enum ControlRequest {
-    /// Send a Pong in response to a Ping
-    Pong(bytes::Bytes),
-    /// Send a Close response
-    CloseResponse,
+use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf};
+use tokio::sync::{mpsc, oneshot, watch};
+use tokio_util::sync::CancellationToken;
+
+const SPLIT_CONTROL_CAPACITY: usize = 32;
+const SPLIT_APPLICATION_CAPACITY: usize = 32;
+const SPLIT_OPEN: u8 = 0;
+const SPLIT_CLOSING: u8 = 1;
+const SPLIT_CLOSED: u8 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalCause {
+    ConnectionClosed,
+    HeartbeatTimeout,
+    IdleTimeout,
 }
 
-/// The read half of a split WebSocket stream
-///
-/// Created by calling `split()` on a `WebSocketStream`.
-/// This half owns the read side of the TCP stream and can operate
-/// completely independently from the write half.
+impl TerminalCause {
+    fn error(self) -> Error {
+        match self {
+            Self::ConnectionClosed => Error::ConnectionClosed,
+            Self::HeartbeatTimeout => Error::HeartbeatTimeout,
+            Self::IdleTimeout => Error::IdleTimeout,
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ControlRequest {
+    Activity(tokio::time::Instant),
+    Ping(Bytes, tokio::time::Instant),
+    Pong(Bytes, tokio::time::Instant),
+    PeerClose,
+    Eof,
+}
+
+#[derive(Debug)]
+enum ApplicationRequest {
+    Send(Message, oneshot::Sender<Result<()>>),
+    Flush(oneshot::Sender<Result<()>>),
+}
+
+struct SplitShared {
+    status: AtomicU8,
+    terminal_tx: watch::Sender<Option<TerminalCause>>,
+    cancel: CancellationToken,
+}
+
+impl SplitShared {
+    fn new(closed: bool) -> Arc<Self> {
+        let (terminal_tx, _) = watch::channel(closed.then_some(TerminalCause::ConnectionClosed));
+        Arc::new(Self {
+            status: AtomicU8::new(if closed { SPLIT_CLOSED } else { SPLIT_OPEN }),
+            terminal_tx,
+            cancel: CancellationToken::new(),
+        })
+    }
+
+    fn begin_closing(&self) -> bool {
+        self.status
+            .compare_exchange(
+                SPLIT_OPEN,
+                SPLIT_CLOSING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
+    }
+
+    fn terminate(&self, cause: TerminalCause) {
+        if self.status.swap(SPLIT_CLOSED, Ordering::AcqRel) != SPLIT_CLOSED {
+            self.terminal_tx.send_replace(Some(cause));
+        }
+    }
+
+    fn is_open(&self) -> bool {
+        self.status.load(Ordering::Acquire) == SPLIT_OPEN
+    }
+}
+
+trait SplitEncoder: 'static {
+    fn encode_message(&mut self, msg: &Message, buf: &mut BytesMut) -> Result<()>;
+    fn encode_pong(&mut self, payload: &[u8], buf: &mut BytesMut);
+    fn encode_close_response(&mut self, buf: &mut BytesMut);
+}
+
+impl SplitEncoder for Protocol {
+    fn encode_message(&mut self, msg: &Message, buf: &mut BytesMut) -> Result<()> {
+        Protocol::encode_message(self, msg, buf)
+    }
+
+    fn encode_pong(&mut self, payload: &[u8], buf: &mut BytesMut) {
+        Protocol::encode_pong(self, payload, buf);
+    }
+
+    fn encode_close_response(&mut self, buf: &mut BytesMut) {
+        Protocol::encode_close_response(self, buf);
+    }
+}
+
+/// The read half of a split WebSocket stream.
 pub struct SplitReader<S> {
-    /// Read half of the underlying stream (no lock!)
     reader: ReadHalf<S>,
-    /// Protocol for decoding
     protocol: Protocol,
-    /// Read buffer
     read_buf: BytesMut,
-    /// Pending messages from last decode
     pending_messages: Vec<Message>,
     pending_index: usize,
-    /// Channel to send control frame requests to writer
-    control_tx: mpsc::UnboundedSender<ControlRequest>,
-    /// Connection state
-    closed: bool,
+    control_tx: mpsc::Sender<ControlRequest>,
+    terminal_rx: watch::Receiver<Option<TerminalCause>>,
+    shared: Arc<SplitShared>,
+    terminal_reported: bool,
 }
 
-/// The write half of a split WebSocket stream
+/// The write half of a split WebSocket stream.
 ///
-/// Created by calling `split()` on a `WebSocketStream`.
-/// This half owns the write side of the TCP stream and can operate
-/// completely independently from the read half.
+/// The transport writer itself is owned by the per-connection control driver.
 pub struct SplitWriter<S> {
-    /// Write half of the underlying stream (no lock!)
-    writer: WriteHalf<S>,
-    /// Protocol for encoding
-    protocol: Protocol,
-    /// Write buffer for encoding
-    write_buf: BytesMut,
-    /// Channel to receive control frame requests from reader
-    control_rx: mpsc::UnboundedReceiver<ControlRequest>,
-    /// Connection state
-    closed: bool,
+    application_tx: mpsc::Sender<ApplicationRequest>,
+    shared: Arc<SplitShared>,
+    _stream: PhantomData<fn() -> S>,
 }
 
 impl<S> WebSocketStream<S>
 where
-    S: AsyncRead + AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    /// Split the WebSocket stream into separate read and write halves
+    /// Split into concurrently usable read and write handles.
     ///
-    /// This allows TRUE concurrent reading and writing from different tasks
-    /// with ZERO lock contention. The underlying TCP stream is split at the
-    /// OS level for maximum performance.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let (mut reader, mut writer) = ws.split();
-    ///
-    /// // Read in one task - NEVER blocks writer
-    /// tokio::spawn(async move {
-    ///     while let Some(msg) = reader.next().await {
-    ///         println!("Got: {:?}", msg);
-    ///     }
-    /// });
-    ///
-    /// // Write in another - NEVER blocks reader
-    /// writer.send(Message::Text("Hello".into())).await?;
-    /// ```
+    /// This starts one connection-scoped Tokio task that exclusively owns the
+    /// transport writer. Dropping either returned half cancels that task.
     pub fn split(self) -> (SplitReader<S>, SplitWriter<S>) {
-        // Split the underlying transport at the OS level
         let (reader, writer) = tokio::io::split(self.inner);
-
-        // Create channel for control frame coordination
-        let (control_tx, control_rx) = mpsc::unbounded_channel();
-
-        // Clone the protocol for both halves (cheap - just config)
+        let (control_tx, control_rx) = mpsc::channel(SPLIT_CONTROL_CAPACITY);
+        let (application_tx, application_rx) = mpsc::channel(SPLIT_APPLICATION_CAPACITY);
+        let shared = SplitShared::new(self.state != StreamState::Open);
+        let terminal_rx = shared.terminal_tx.subscribe();
         let reader_protocol = Protocol::new(
             self.protocol.role,
             self.config.max_frame_size,
             self.config.max_message_size,
         );
-        let writer_protocol = self.protocol;
+
+        tokio::spawn(split_writer_driver(
+            writer,
+            self.protocol,
+            self.config,
+            control_rx,
+            application_rx,
+            shared.clone(),
+        ));
 
         (
             SplitReader {
@@ -742,14 +908,14 @@ where
                 pending_messages: self.pending_messages,
                 pending_index: self.pending_index,
                 control_tx,
-                closed: self.state == StreamState::Closed,
+                terminal_rx,
+                shared: shared.clone(),
+                terminal_reported: false,
             },
             SplitWriter {
-                writer,
-                protocol: writer_protocol,
-                write_buf: BytesMut::with_capacity(1024),
-                control_rx,
-                closed: self.state == StreamState::Closed,
+                application_tx,
+                shared,
+                _stream: PhantomData,
             },
         )
     }
@@ -759,170 +925,411 @@ impl<S> SplitReader<S>
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    /// Receive the next message
+    /// Receive the next message.
     ///
-    /// Returns `None` when the connection is closed.
-    /// This method NEVER blocks the writer - true concurrent I/O!
+    /// Ping and Pong frames remain visible after their automatic state-machine
+    /// processing. A terminal heartbeat/idle cause is yielded once as an error.
     pub async fn next(&mut self) -> Option<Result<Message>> {
         loop {
-            // Check for connection closed
-            if self.closed {
-                return None;
+            if let Some(result) = self.take_terminal() {
+                return result;
             }
 
-            // Return any pending messages first
             if self.pending_index < self.pending_messages.len() {
                 let msg = self.pending_messages[self.pending_index].clone();
                 self.pending_index += 1;
-
                 if self.pending_index >= self.pending_messages.len() {
                     self.pending_messages.clear();
                     self.pending_index = 0;
                 }
 
-                // Handle control frames - send requests to writer via channel
-                match &msg {
+                let request = match &msg {
                     Message::Ping(data) => {
-                        // Request writer to send pong (non-blocking!)
-                        let _ = self.control_tx.send(ControlRequest::Pong(data.clone()));
-                        // Continue to next message (user doesn't see Ping)
-                        continue;
+                        ControlRequest::Ping(data.clone(), tokio::time::Instant::now())
                     }
-                    Message::Close(reason) => {
-                        if !self.closed {
-                            // Request writer to send close response
-                            let _ = self.control_tx.send(ControlRequest::CloseResponse);
-                            self.closed = true;
-                        }
-                        return Some(Ok(Message::Close(reason.clone())));
+                    Message::Pong(data) => {
+                        ControlRequest::Pong(data.clone(), tokio::time::Instant::now())
                     }
-                    Message::Pong(_) => {
-                        // User doesn't typically need to see Pong
-                        continue;
+                    Message::Close(_) => {
+                        self.shared.begin_closing();
+                        ControlRequest::PeerClose
                     }
-                    _ => {}
+                    _ => ControlRequest::Activity(tokio::time::Instant::now()),
+                };
+                if self.control_tx.send(request).await.is_err() {
+                    self.shared.terminate(TerminalCause::ConnectionClosed);
+                    continue;
                 }
-
                 return Some(Ok(msg));
             }
 
-            // Need to read more data - NO LOCK HERE!
-            // Reserve space if needed
             if self.read_buf.capacity() - self.read_buf.len() < 4096 {
                 self.read_buf.reserve(8192);
             }
 
-            match self.reader.read_buf(&mut self.read_buf).await {
-                Ok(0) => {
-                    // EOF - connection closed
-                    self.closed = true;
-                    return None;
+            tokio::select! {
+                biased;
+                changed = self.terminal_rx.changed() => {
+                    if changed.is_err() {
+                        self.shared.terminate(TerminalCause::ConnectionClosed);
+                    }
                 }
-                Ok(_n) => {
-                    // Process the new data
-                    match self.protocol.process(&mut self.read_buf) {
-                        Ok(messages) => {
-                            if !messages.is_empty() {
+                result = self.reader.read_buf(&mut self.read_buf) => {
+                    match result {
+                        Ok(0) => {
+                            let _ = self.control_tx.send(ControlRequest::Eof).await;
+                            self.shared.terminate(TerminalCause::ConnectionClosed);
+                        }
+                        Ok(_) => match self.protocol.process(&mut self.read_buf) {
+                            Ok(messages) if !messages.is_empty() => {
                                 self.pending_messages = messages;
                                 self.pending_index = 0;
                             }
+                            Ok(_) => {}
+                            Err(error) => {
+                                self.shared.terminate(TerminalCause::ConnectionClosed);
+                                return Some(Err(error));
+                            }
+                        },
+                        Err(error) => {
+                            self.shared.terminate(TerminalCause::ConnectionClosed);
+                            return Some(Err(error.into()));
                         }
-                        Err(e) => return Some(Err(e)),
                     }
-                    // Continue loop to check for messages
-                }
-                Err(e) => {
-                    return Some(Err(e.into()));
                 }
             }
         }
     }
 
-    /// Check if the connection is closed
+    fn take_terminal(&mut self) -> Option<Option<Result<Message>>> {
+        if self.shared.status.load(Ordering::Acquire) != SPLIT_CLOSED {
+            return None;
+        }
+        if self.terminal_reported {
+            return Some(None);
+        }
+        self.terminal_reported = true;
+        match *self.terminal_rx.borrow() {
+            Some(TerminalCause::HeartbeatTimeout) => Some(Some(Err(Error::HeartbeatTimeout))),
+            Some(TerminalCause::IdleTimeout) => Some(Some(Err(Error::IdleTimeout))),
+            _ => Some(None),
+        }
+    }
+
+    /// Check whether the connection is closing or closed.
     pub fn is_closed(&self) -> bool {
-        self.closed
+        !self.shared.is_open()
     }
 }
 
-impl<S> SplitWriter<S>
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
-    /// Send a message
-    ///
-    /// This method NEVER blocks the reader - true concurrent I/O!
+impl<S> Drop for SplitReader<S> {
+    fn drop(&mut self) {
+        self.shared.cancel.cancel();
+    }
+}
+
+impl<S> SplitWriter<S> {
+    /// Send a message through the connection-scoped writer driver.
     pub async fn send(&mut self, msg: Message) -> Result<()> {
-        if self.closed {
-            return Err(Error::ConnectionClosed);
+        if !self.shared.is_open() {
+            return Err(self.current_error());
         }
-
-        // Process any pending control frame requests from reader first
-        self.process_control_requests().await?;
-
-        if msg.is_close() {
-            self.closed = true;
-        }
-
-        // Encode message - NO LOCK HERE!
-        self.write_buf.clear();
-        self.protocol.encode_message(&msg, &mut self.write_buf)?;
-
-        // Write to the underlying stream - NO LOCK HERE!
-        self.writer.write_all(&self.write_buf).await?;
-        self.writer.flush().await?;
-        Ok(())
+        let (tx, rx) = oneshot::channel();
+        self.application_tx
+            .send(ApplicationRequest::Send(msg, tx))
+            .await
+            .map_err(|_| self.current_error())?;
+        rx.await.map_err(|_| self.current_error())?
     }
 
-    /// Process control frame requests from the reader
-    async fn process_control_requests(&mut self) -> Result<()> {
-        // Drain all pending control requests
-        while let Ok(req) = self.control_rx.try_recv() {
-            self.write_buf.clear();
-
-            match req {
-                ControlRequest::Pong(data) => {
-                    self.protocol.encode_pong(&data, &mut self.write_buf);
-                }
-                ControlRequest::CloseResponse => {
-                    self.protocol.encode_close_response(&mut self.write_buf);
-                    self.closed = true;
-                }
-            }
-
-            if !self.write_buf.is_empty() {
-                self.writer.write_all(&self.write_buf).await?;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Send a text message
+    /// Send a text message.
     pub async fn send_text(&mut self, text: impl Into<String>) -> Result<()> {
         self.send(Message::text(text)).await
     }
 
-    /// Send a binary message
-    pub async fn send_binary(&mut self, data: bytes::Bytes) -> Result<()> {
+    /// Send a binary message.
+    pub async fn send_binary(&mut self, data: Bytes) -> Result<()> {
         self.send(Message::Binary(data)).await
     }
 
-    /// Send a close frame
+    /// Send a local Close frame.
     pub async fn close(&mut self, code: u16, reason: &str) -> Result<()> {
         self.send(Message::Close(Some(CloseReason::new(code, reason))))
             .await
     }
 
-    /// Check if the connection is closed
-    pub fn is_closed(&self) -> bool {
-        self.closed
+    /// Flush all writes accepted before this request.
+    pub async fn flush(&mut self) -> Result<()> {
+        if !self.shared.is_open() {
+            return Err(self.current_error());
+        }
+        let (tx, rx) = oneshot::channel();
+        self.application_tx
+            .send(ApplicationRequest::Flush(tx))
+            .await
+            .map_err(|_| self.current_error())?;
+        rx.await.map_err(|_| self.current_error())?
     }
 
-    /// Flush any pending control responses
-    pub async fn flush(&mut self) -> Result<()> {
-        self.process_control_requests().await?;
-        self.writer.flush().await.map_err(Into::into)
+    /// Check whether the connection is closing or closed.
+    pub fn is_closed(&self) -> bool {
+        !self.shared.is_open()
     }
+
+    fn current_error(&self) -> Error {
+        self.shared
+            .terminal_tx
+            .borrow()
+            .map_or(Error::ConnectionClosed, TerminalCause::error)
+    }
+}
+
+impl<S> Drop for SplitWriter<S> {
+    fn drop(&mut self) {
+        self.shared.cancel.cancel();
+    }
+}
+
+async fn split_writer_driver<W, E>(
+    mut writer: W,
+    mut encoder: E,
+    config: Config,
+    mut control_rx: mpsc::Receiver<ControlRequest>,
+    mut application_rx: mpsc::Receiver<ApplicationRequest>,
+    shared: Arc<SplitShared>,
+) where
+    W: AsyncWrite + Unpin,
+    E: SplitEncoder,
+{
+    let epoch = tokio::time::Instant::now();
+    let mut heartbeat = Heartbeat::new(&config, 0);
+    let mut closing_deadline = None;
+    let mut local_close_sent = false;
+    let mut write_buf = BytesMut::with_capacity(config.write_buffer_size);
+
+    loop {
+        let now_ms = epoch.elapsed().as_millis() as u64;
+        let heartbeat_deadline = heartbeat.next_deadline();
+        let heartbeat_delay = heartbeat_deadline
+            .map(|deadline| Duration::from_millis(deadline.at().saturating_sub(now_ms)))
+            .unwrap_or(Duration::from_secs(365 * 24 * 60 * 60));
+        let close_delay = closing_deadline
+            .map(|deadline: tokio::time::Instant| {
+                deadline.saturating_duration_since(tokio::time::Instant::now())
+            })
+            .unwrap_or(Duration::from_secs(365 * 24 * 60 * 60));
+
+        tokio::select! {
+            biased;
+            _ = shared.cancel.cancelled() => {
+                shared.terminate(TerminalCause::ConnectionClosed);
+                break;
+            }
+            request = control_rx.recv() => {
+                let Some(request) = request else {
+                    shared.terminate(TerminalCause::ConnectionClosed);
+                    break;
+                };
+                match request {
+                    ControlRequest::Activity(received_at) => {
+                        let received_ms =
+                            received_at.saturating_duration_since(epoch).as_millis() as u64;
+                        heartbeat.on_inbound(received_ms, None);
+                    }
+                    ControlRequest::Ping(payload, received_at) => {
+                        let received_ms =
+                            received_at.saturating_duration_since(epoch).as_millis() as u64;
+                        heartbeat.on_inbound(received_ms, None);
+                        write_buf.clear();
+                        encoder.encode_pong(&payload, &mut write_buf);
+                        if write_split_bytes(&mut writer, &write_buf, &shared.cancel).await.is_err() {
+                            shared.terminate(TerminalCause::ConnectionClosed);
+                            break;
+                        }
+                    }
+                    ControlRequest::Pong(payload, received_at) => {
+                        let received_ms =
+                            received_at.saturating_duration_since(epoch).as_millis() as u64;
+                        heartbeat.on_inbound(received_ms, Some(&payload));
+                    }
+                    ControlRequest::PeerClose => {
+                        heartbeat.stop();
+                        if !local_close_sent {
+                            write_buf.clear();
+                            encoder.encode_close_response(&mut write_buf);
+                            let _ =
+                                write_split_bytes(&mut writer, &write_buf, &shared.cancel).await;
+                        }
+                        let _ = bounded_shutdown(&mut writer, config.close_timeout).await;
+                        shared.terminate(TerminalCause::ConnectionClosed);
+                        break;
+                    }
+                    ControlRequest::Eof => {
+                        heartbeat.stop();
+                        shared.terminate(TerminalCause::ConnectionClosed);
+                        break;
+                    }
+                }
+            }
+            request = application_rx.recv(), if shared.is_open() => {
+                let Some(request) = request else {
+                    shared.terminate(TerminalCause::ConnectionClosed);
+                    break;
+                };
+                match request {
+                    ApplicationRequest::Send(message, completion) => {
+                        if !shared.is_open() {
+                            let _ = completion.send(Err(Error::ConnectionClosed));
+                            continue;
+                        }
+                        let is_close = message.is_close();
+                        if is_close {
+                            shared.begin_closing();
+                            heartbeat.stop();
+                            local_close_sent = true;
+                        }
+                        write_buf.clear();
+                        let result = encoder.encode_message(&message, &mut write_buf);
+                        let result = match result {
+                            Ok(()) => {
+                                write_split_bytes(&mut writer, &write_buf, &shared.cancel).await
+                            }
+                            Err(error) => Err(error),
+                        };
+                        let failed = result.is_err();
+                        let _ = completion.send(result);
+                        if failed {
+                            shared.terminate(TerminalCause::ConnectionClosed);
+                            break;
+                        }
+                        if is_close {
+                            closing_deadline = Some(
+                                tokio::time::Instant::now()
+                                    + Duration::from_secs(config.close_timeout.into()),
+                            );
+                        }
+                    }
+                    ApplicationRequest::Flush(completion) => {
+                        let result = tokio::select! {
+                            result = writer.flush() => result.map_err(Into::into),
+                            _ = shared.cancel.cancelled() => Err(Error::ConnectionClosed),
+                        };
+                        let failed = result.is_err();
+                        let _ = completion.send(result);
+                        if failed {
+                            shared.terminate(TerminalCause::ConnectionClosed);
+                            break;
+                        }
+                    }
+                }
+            }
+            _ = tokio::time::sleep(close_delay), if closing_deadline.is_some() => {
+                let _ = bounded_shutdown(&mut writer, config.close_timeout).await;
+                shared.terminate(TerminalCause::ConnectionClosed);
+                break;
+            }
+            _ = tokio::time::sleep(heartbeat_delay), if heartbeat_deadline.is_some() && shared.is_open() => {
+                let now_ms = epoch.elapsed().as_millis() as u64;
+                match heartbeat.next_deadline() {
+                    Some(Deadline::Ping(at)) if at <= now_ms => {
+                        if let Some(payload) = heartbeat.ping_due(now_ms) {
+                            write_buf.clear();
+                            if encoder
+                                .encode_message(&Message::Ping(payload), &mut write_buf)
+                                .is_err()
+                                || write_split_bytes(&mut writer, &write_buf, &shared.cancel)
+                                    .await
+                                    .is_err()
+                            {
+                                shared.terminate(TerminalCause::ConnectionClosed);
+                                break;
+                            }
+                            heartbeat.ping_flushed(epoch.elapsed().as_millis() as u64);
+                        }
+                    }
+                    Some(Deadline::Pong(at)) if at <= now_ms => {
+                        timeout_close(
+                            &mut writer,
+                            &mut encoder,
+                            &config,
+                            config.pong_timeout_close_code,
+                            &config.pong_timeout_close_reason,
+                            &shared.cancel,
+                        ).await;
+                        shared.terminate(TerminalCause::HeartbeatTimeout);
+                        break;
+                    }
+                    Some(Deadline::Idle(at)) if at <= now_ms => {
+                        timeout_close(
+                            &mut writer,
+                            &mut encoder,
+                            &config,
+                            CloseReason::GOING_AWAY,
+                            "Connection idle timeout",
+                            &shared.cancel,
+                        ).await;
+                        shared.terminate(TerminalCause::IdleTimeout);
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+async fn write_split_bytes<W>(
+    writer: &mut W,
+    bytes: &[u8],
+    cancel: &CancellationToken,
+) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    tokio::select! {
+        result = async {
+            writer.write_all(bytes).await?;
+            writer.flush().await?;
+            Ok::<(), std::io::Error>(())
+        } => result.map_err(Into::into),
+        _ = cancel.cancelled() => Err(Error::ConnectionClosed),
+    }
+}
+
+async fn bounded_shutdown<W>(writer: &mut W, seconds: u32) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+{
+    tokio::time::timeout(Duration::from_secs(seconds.into()), async {
+        writer.flush().await?;
+        writer.shutdown().await
+    })
+    .await
+    .map_err(|_| Error::ConnectionClosed)?
+    .map_err(Into::into)
+}
+
+async fn timeout_close<W, E>(
+    writer: &mut W,
+    encoder: &mut E,
+    config: &Config,
+    code: u16,
+    reason: &str,
+    cancel: &CancellationToken,
+) where
+    W: AsyncWrite + Unpin,
+    E: SplitEncoder,
+{
+    let mut buf = BytesMut::with_capacity(128);
+    let close = Message::Close(Some(CloseReason::new(code, bounded_close_reason(reason))));
+    if encoder.encode_message(&close, &mut buf).is_ok() {
+        let _ = tokio::time::timeout(
+            Duration::from_secs(config.close_timeout.into()),
+            write_split_bytes(writer, &buf, cancel),
+        )
+        .await;
+    }
+    let _ = bounded_shutdown(writer, config.close_timeout).await;
 }
 
 // ============================================================================
@@ -946,9 +1353,13 @@ pin_project! {
         pending_messages: Vec<Message>,
         pending_index: usize,
         pending_control_message: Option<Message>,
+        pending_terminal_error: Option<Error>,
         flush_on_read: bool,
         close_after_flush: bool,
-        auto_ping_sleep: Option<Pin<Box<tokio::time::Sleep>>>,
+        ping_flush_pending: bool,
+        clock_epoch: tokio::time::Instant,
+        heartbeat: Heartbeat,
+        heartbeat_sleep: Option<Pin<Box<tokio::time::Sleep>>>,
         high_water_mark: usize,
         low_water_mark: usize,
     }
@@ -967,6 +1378,8 @@ where
             deflate_config,
         );
 
+        let clock_epoch = tokio::time::Instant::now();
+        let heartbeat = Heartbeat::new(&config, 0);
         Self {
             inner,
             protocol,
@@ -977,9 +1390,13 @@ where
             pending_messages: Vec::new(),
             pending_index: 0,
             pending_control_message: None,
+            pending_terminal_error: None,
             flush_on_read: false,
             close_after_flush: false,
-            auto_ping_sleep: None,
+            ping_flush_pending: false,
+            clock_epoch,
+            heartbeat,
+            heartbeat_sleep: None,
             high_water_mark: DEFAULT_HIGH_WATER_MARK,
             low_water_mark: DEFAULT_LOW_WATER_MARK,
         }
@@ -993,6 +1410,8 @@ where
             deflate_config,
         );
 
+        let clock_epoch = tokio::time::Instant::now();
+        let heartbeat = Heartbeat::new(&config, 0);
         Self {
             inner,
             protocol,
@@ -1003,9 +1422,13 @@ where
             pending_messages: Vec::new(),
             pending_index: 0,
             pending_control_message: None,
+            pending_terminal_error: None,
             flush_on_read: false,
             close_after_flush: false,
-            auto_ping_sleep: None,
+            ping_flush_pending: false,
+            clock_epoch,
+            heartbeat,
+            heartbeat_sleep: None,
             high_water_mark: DEFAULT_HIGH_WATER_MARK,
             low_water_mark: DEFAULT_LOW_WATER_MARK,
         }
@@ -1157,17 +1580,32 @@ where
                     Poll::Ready(Ok(())) => {
                         let this = self.as_mut().get_mut();
                         this.flush_on_read = false;
+                        if this.ping_flush_pending {
+                            this.ping_flush_pending = false;
+                            let now = this.clock_epoch.elapsed().as_millis() as u64;
+                            this.heartbeat.ping_flushed(now);
+                            this.heartbeat_sleep = None;
+                        }
 
                         if this.close_after_flush {
                             this.close_after_flush = false;
                             this.state = StreamState::Closed;
                         }
 
+                        if let Some(error) = this.pending_terminal_error.take() {
+                            return Poll::Ready(Some(Err(error)));
+                        }
                         if let Some(msg) = this.pending_control_message.take() {
                             return Poll::Ready(Some(Ok(msg)));
                         }
                     }
-                    Poll::Ready(Err(e)) => return Poll::Ready(Some(Err(e))),
+                    Poll::Ready(Err(e)) => {
+                        let this = self.as_mut().get_mut();
+                        this.state = StreamState::Closed;
+                        this.heartbeat.stop();
+                        this.heartbeat_sleep = None;
+                        return Poll::Ready(Some(Err(e)));
+                    }
                     Poll::Pending => return Poll::Pending,
                 }
             }
@@ -1176,27 +1614,82 @@ where
                 return Poll::Ready(None);
             }
 
-            if self.config.auto_ping && self.config.ping_interval > 0 {
-                let interval = Duration::from_secs(self.config.ping_interval.into());
-                let this = self.as_mut().get_mut();
-                let sleep = this
-                    .auto_ping_sleep
-                    .get_or_insert_with(|| Box::pin(tokio::time::sleep(interval)));
-
-                if sleep.as_mut().poll(cx).is_ready() {
-                    this.auto_ping_sleep = Some(Box::pin(tokio::time::sleep(interval)));
-                    if let Err(e) = this
-                        .protocol
-                        .encode_message(&Message::Ping(Bytes::new()), this.write_buf.buffer_mut())
-                    {
-                        return Poll::Ready(Some(Err(e)));
+            let deadline = self.heartbeat.next_deadline();
+            if let Some(deadline) = deadline {
+                let now = self.clock_epoch.elapsed().as_millis() as u64;
+                if deadline.at() <= now {
+                    let this = self.as_mut().get_mut();
+                    match deadline {
+                        Deadline::Ping(_) => {
+                            if let Some(payload) = this.heartbeat.ping_due(now) {
+                                if let Err(e) = this.protocol.encode_message(
+                                    &Message::Ping(payload),
+                                    this.write_buf.buffer_mut(),
+                                ) {
+                                    this.state = StreamState::Closed;
+                                    this.heartbeat.stop();
+                                    return Poll::Ready(Some(Err(e)));
+                                }
+                                this.ping_flush_pending = true;
+                                this.flush_on_read = true;
+                            }
+                        }
+                        Deadline::Pong(_) | Deadline::Idle(_) => {
+                            let (code, reason, error) = match deadline {
+                                Deadline::Pong(_) => (
+                                    this.config.pong_timeout_close_code,
+                                    bounded_close_reason(&this.config.pong_timeout_close_reason),
+                                    Error::HeartbeatTimeout,
+                                ),
+                                Deadline::Idle(_) => (
+                                    CloseReason::GOING_AWAY,
+                                    "Connection idle timeout".to_string(),
+                                    Error::IdleTimeout,
+                                ),
+                                Deadline::Ping(_) => unreachable!(),
+                            };
+                            let close = Message::Close(Some(CloseReason::new(code, reason)));
+                            if let Err(e) = this
+                                .protocol
+                                .encode_message(&close, this.write_buf.buffer_mut())
+                            {
+                                this.state = StreamState::Closed;
+                                this.heartbeat.stop();
+                                return Poll::Ready(Some(Err(e)));
+                            }
+                            this.heartbeat.stop();
+                            this.state = StreamState::CloseSent;
+                            this.pending_terminal_error = Some(error);
+                            this.flush_on_read = true;
+                            this.close_after_flush = true;
+                        }
                     }
-                    this.flush_on_read = true;
+                    this.heartbeat_sleep = None;
+                    continue;
+                }
+
+                let delay = Duration::from_millis(deadline.at().saturating_sub(now));
+                let sleep = self
+                    .as_mut()
+                    .get_mut()
+                    .heartbeat_sleep
+                    .get_or_insert_with(|| Box::pin(tokio::time::sleep(delay)));
+                if sleep.as_mut().poll(cx).is_ready() {
+                    self.as_mut().get_mut().heartbeat_sleep = None;
                     continue;
                 }
             }
 
             if let Some(msg) = self.as_mut().get_mut().next_pending_message() {
+                let this = self.as_mut().get_mut();
+                let now = this.clock_epoch.elapsed().as_millis() as u64;
+                let pong = match &msg {
+                    Message::Pong(payload) => Some(payload),
+                    _ => None,
+                };
+                this.heartbeat.on_inbound(now, pong);
+                this.heartbeat_sleep = None;
+
                 match &msg {
                     Message::Ping(data) => {
                         let this = self.as_mut().get_mut();
@@ -1207,6 +1700,8 @@ where
                     }
                     Message::Close(reason) => {
                         let this = self.as_mut().get_mut();
+                        this.heartbeat.stop();
+                        this.heartbeat_sleep = None;
                         if this.state == StreamState::Open {
                             this.protocol
                                 .encode_close_response(this.write_buf.buffer_mut());
@@ -1225,13 +1720,24 @@ where
             match self.as_mut().poll_read_more(cx) {
                 Poll::Ready(Ok(0)) => {
                     self.as_mut().get_mut().state = StreamState::Closed;
+                    self.as_mut().get_mut().heartbeat.stop();
                     return Poll::Ready(None);
                 }
                 Poll::Ready(Ok(_n)) => match self.as_mut().get_mut().process_read_buf() {
                     Ok(()) => continue,
-                    Err(e) => return Poll::Ready(Some(Err(e))),
+                    Err(e) => {
+                        let this = self.as_mut().get_mut();
+                        this.state = StreamState::Closed;
+                        this.heartbeat.stop();
+                        this.heartbeat_sleep = None;
+                        return Poll::Ready(Some(Err(e)));
+                    }
                 },
                 Poll::Ready(Err(e)) => {
+                    let this = self.as_mut().get_mut();
+                    this.state = StreamState::Closed;
+                    this.heartbeat.stop();
+                    this.heartbeat_sleep = None;
                     return Poll::Ready(Some(Err(e.into())));
                 }
                 Poll::Pending => {
@@ -1250,7 +1756,7 @@ where
     type Error = Error;
 
     fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
-        if self.state == StreamState::Closed {
+        if self.state != StreamState::Open {
             return Poll::Ready(Err(Error::ConnectionClosed));
         }
         Poll::Ready(Ok(()))
@@ -1259,12 +1765,14 @@ where
     fn start_send(self: Pin<&mut Self>, item: Message) -> Result<()> {
         let this = self.get_mut();
 
-        if this.state == StreamState::Closed {
+        if this.state != StreamState::Open {
             return Err(Error::ConnectionClosed);
         }
 
         if item.is_close() {
             this.state = StreamState::CloseSent;
+            this.heartbeat.stop();
+            this.heartbeat_sleep = None;
         }
 
         this.protocol
@@ -1283,12 +1791,18 @@ where
 
             match Pin::new(&mut this.inner).poll_write_vectored(cx, &slices) {
                 Poll::Ready(Ok(0)) => {
+                    this.state = StreamState::Closed;
+                    this.heartbeat.stop();
+                    this.heartbeat_sleep = None;
                     return Poll::Ready(Err(Error::ConnectionClosed));
                 }
                 Poll::Ready(Ok(n)) => {
                     this.write_buf.consume(n);
                 }
                 Poll::Ready(Err(e)) => {
+                    this.state = StreamState::Closed;
+                    this.heartbeat.stop();
+                    this.heartbeat_sleep = None;
                     return Poll::Ready(Err(e.into()));
                 }
                 Poll::Pending => {
@@ -1297,9 +1811,15 @@ where
             }
         }
 
-        match Pin::new(&mut self.as_mut().get_mut().inner).poll_flush(cx) {
+        let this = self.as_mut().get_mut();
+        match Pin::new(&mut this.inner).poll_flush(cx) {
             Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+            Poll::Ready(Err(e)) => {
+                this.state = StreamState::Closed;
+                this.heartbeat.stop();
+                this.heartbeat_sleep = None;
+                Poll::Ready(Err(e.into()))
+            }
             Poll::Pending => Poll::Pending,
         }
     }
@@ -1349,10 +1869,10 @@ pub struct CompressedSplitReader<S> {
     /// Pending messages from last decode
     pending_messages: Vec<Message>,
     pending_index: usize,
-    /// Channel to send control frame requests to writer
-    control_tx: mpsc::UnboundedSender<ControlRequest>,
-    /// Connection state
-    closed: bool,
+    control_tx: mpsc::Sender<ControlRequest>,
+    terminal_rx: watch::Receiver<Option<TerminalCause>>,
+    shared: Arc<SplitShared>,
+    terminal_reported: bool,
 }
 
 /// The write half of a split compressed WebSocket stream
@@ -1362,22 +1882,30 @@ pub struct CompressedSplitReader<S> {
 /// completely independently from the read half.
 #[cfg(feature = "permessage-deflate")]
 pub struct CompressedSplitWriter<S> {
-    /// Write half of the underlying stream
-    writer: WriteHalf<S>,
-    /// Protocol for encoding with compression
-    protocol: crate::protocol::CompressedWriterProtocol,
-    /// Write buffer for encoding
-    write_buf: BytesMut,
-    /// Channel to receive control frame requests from reader
-    control_rx: mpsc::UnboundedReceiver<ControlRequest>,
-    /// Connection state
-    closed: bool,
+    application_tx: mpsc::Sender<ApplicationRequest>,
+    shared: Arc<SplitShared>,
+    _stream: PhantomData<fn() -> S>,
+}
+
+#[cfg(feature = "permessage-deflate")]
+impl SplitEncoder for crate::protocol::CompressedWriterProtocol {
+    fn encode_message(&mut self, msg: &Message, buf: &mut BytesMut) -> Result<()> {
+        crate::protocol::CompressedWriterProtocol::encode_message(self, msg, buf)
+    }
+
+    fn encode_pong(&mut self, payload: &[u8], buf: &mut BytesMut) {
+        crate::protocol::CompressedWriterProtocol::encode_pong(self, payload, buf);
+    }
+
+    fn encode_close_response(&mut self, buf: &mut BytesMut) {
+        crate::protocol::CompressedWriterProtocol::encode_close_response(self, buf);
+    }
 }
 
 #[cfg(feature = "permessage-deflate")]
 impl<S> CompressedWebSocketStream<S>
 where
-    S: AsyncRead + AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
     /// Split the compressed WebSocket stream into separate read and write halves
     ///
@@ -1408,13 +1936,24 @@ where
         // Split the underlying transport at the OS level
         let (reader, writer) = tokio::io::split(self.inner);
 
-        // Create channel for control frame coordination
-        let (control_tx, control_rx) = mpsc::unbounded_channel();
+        let (control_tx, control_rx) = mpsc::channel(SPLIT_CONTROL_CAPACITY);
+        let (application_tx, application_rx) = mpsc::channel(SPLIT_APPLICATION_CAPACITY);
+        let shared = SplitShared::new(self.state != StreamState::Open);
+        let terminal_rx = shared.terminal_tx.subscribe();
 
         // Split the protocol into reader and writer halves
         let (reader_protocol, writer_protocol) = self
             .protocol
             .split(self.config.max_frame_size, self.config.max_message_size);
+
+        tokio::spawn(split_writer_driver(
+            writer,
+            writer_protocol,
+            self.config,
+            control_rx,
+            application_rx,
+            shared.clone(),
+        ));
 
         (
             CompressedSplitReader {
@@ -1424,14 +1963,14 @@ where
                 pending_messages: self.pending_messages,
                 pending_index: self.pending_index,
                 control_tx,
-                closed: self.state == StreamState::Closed,
+                terminal_rx,
+                shared: shared.clone(),
+                terminal_reported: false,
             },
             CompressedSplitWriter {
-                writer,
-                protocol: writer_protocol,
-                write_buf: BytesMut::with_capacity(1024),
-                control_rx,
-                closed: self.state == StreamState::Closed,
+                application_tx,
+                shared,
+                _stream: PhantomData,
             },
         )
     }
@@ -1448,12 +1987,10 @@ where
     /// This method NEVER blocks the writer - true concurrent I/O!
     pub async fn next(&mut self) -> Option<Result<Message>> {
         loop {
-            // Check for connection closed
-            if self.closed {
-                return None;
+            if let Some(result) = self.take_terminal() {
+                return result;
             }
 
-            // Return any pending messages first
             if self.pending_index < self.pending_messages.len() {
                 let msg = self.pending_messages[self.pending_index].clone();
                 self.pending_index += 1;
@@ -1463,122 +2000,104 @@ where
                     self.pending_index = 0;
                 }
 
-                // Handle control frames - send requests to writer via channel
-                match &msg {
+                let request = match &msg {
                     Message::Ping(data) => {
-                        // Request writer to send pong (non-blocking!)
-                        let _ = self.control_tx.send(ControlRequest::Pong(data.clone()));
-                        // Continue to next message (user doesn't see Ping)
-                        continue;
+                        ControlRequest::Ping(data.clone(), tokio::time::Instant::now())
                     }
-                    Message::Close(reason) => {
-                        if !self.closed {
-                            // Request writer to send close response
-                            let _ = self.control_tx.send(ControlRequest::CloseResponse);
-                            self.closed = true;
-                        }
-                        return Some(Ok(Message::Close(reason.clone())));
+                    Message::Pong(data) => {
+                        ControlRequest::Pong(data.clone(), tokio::time::Instant::now())
                     }
-                    Message::Pong(_) => {
-                        // User doesn't typically need to see Pong
-                        continue;
+                    Message::Close(_) => {
+                        self.shared.begin_closing();
+                        ControlRequest::PeerClose
                     }
-                    _ => {}
+                    _ => ControlRequest::Activity(tokio::time::Instant::now()),
+                };
+                if self.control_tx.send(request).await.is_err() {
+                    self.shared.terminate(TerminalCause::ConnectionClosed);
+                    continue;
                 }
-
                 return Some(Ok(msg));
             }
 
-            // Need to read more data - NO LOCK HERE!
-            // Reserve space if needed
             if self.read_buf.capacity() - self.read_buf.len() < 4096 {
                 self.read_buf.reserve(8192);
             }
 
-            match self.reader.read_buf(&mut self.read_buf).await {
-                Ok(0) => {
-                    // EOF - connection closed
-                    self.closed = true;
-                    return None;
+            tokio::select! {
+                biased;
+                changed = self.terminal_rx.changed() => {
+                    if changed.is_err() {
+                        self.shared.terminate(TerminalCause::ConnectionClosed);
+                    }
                 }
-                Ok(_n) => {
-                    // Process the new data
-                    match self.protocol.process(&mut self.read_buf) {
-                        Ok(messages) => {
-                            if !messages.is_empty() {
+                result = self.reader.read_buf(&mut self.read_buf) => {
+                    match result {
+                        Ok(0) => {
+                            let _ = self.control_tx.send(ControlRequest::Eof).await;
+                            self.shared.terminate(TerminalCause::ConnectionClosed);
+                        }
+                        Ok(_) => match self.protocol.process(&mut self.read_buf) {
+                            Ok(messages) if !messages.is_empty() => {
                                 self.pending_messages = messages;
                                 self.pending_index = 0;
                             }
+                            Ok(_) => {}
+                            Err(error) => {
+                                self.shared.terminate(TerminalCause::ConnectionClosed);
+                                return Some(Err(error));
+                            }
+                        },
+                        Err(error) => {
+                            self.shared.terminate(TerminalCause::ConnectionClosed);
+                            return Some(Err(error.into()));
                         }
-                        Err(e) => return Some(Err(e)),
                     }
-                    // Continue loop to check for messages
-                }
-                Err(e) => {
-                    return Some(Err(e.into()));
                 }
             }
         }
     }
 
-    /// Check if the connection is closed
+    fn take_terminal(&mut self) -> Option<Option<Result<Message>>> {
+        if self.shared.status.load(Ordering::Acquire) != SPLIT_CLOSED {
+            return None;
+        }
+        if self.terminal_reported {
+            return Some(None);
+        }
+        self.terminal_reported = true;
+        match *self.terminal_rx.borrow() {
+            Some(TerminalCause::HeartbeatTimeout) => Some(Some(Err(Error::HeartbeatTimeout))),
+            Some(TerminalCause::IdleTimeout) => Some(Some(Err(Error::IdleTimeout))),
+            _ => Some(None),
+        }
+    }
+
     pub fn is_closed(&self) -> bool {
-        self.closed
+        !self.shared.is_open()
     }
 }
 
 #[cfg(feature = "permessage-deflate")]
-impl<S> CompressedSplitWriter<S>
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
-    /// Send a message
-    ///
-    /// This method NEVER blocks the reader - true concurrent I/O!
-    pub async fn send(&mut self, msg: Message) -> Result<()> {
-        if self.closed {
-            return Err(Error::ConnectionClosed);
-        }
-
-        // Process any pending control frame requests from reader first
-        self.process_control_requests().await?;
-
-        if msg.is_close() {
-            self.closed = true;
-        }
-
-        // Encode message with compression - NO LOCK HERE!
-        self.write_buf.clear();
-        self.protocol.encode_message(&msg, &mut self.write_buf)?;
-
-        // Write to the underlying stream - NO LOCK HERE!
-        self.writer.write_all(&self.write_buf).await?;
-        self.writer.flush().await?;
-        Ok(())
+impl<S> Drop for CompressedSplitReader<S> {
+    fn drop(&mut self) {
+        self.shared.cancel.cancel();
     }
+}
 
-    /// Process control frame requests from the reader
-    async fn process_control_requests(&mut self) -> Result<()> {
-        // Drain all pending control requests
-        while let Ok(req) = self.control_rx.try_recv() {
-            self.write_buf.clear();
-
-            match req {
-                ControlRequest::Pong(data) => {
-                    self.protocol.encode_pong(&data, &mut self.write_buf);
-                }
-                ControlRequest::CloseResponse => {
-                    self.protocol.encode_close_response(&mut self.write_buf);
-                    self.closed = true;
-                }
-            }
-
-            if !self.write_buf.is_empty() {
-                self.writer.write_all(&self.write_buf).await?;
-            }
+#[cfg(feature = "permessage-deflate")]
+impl<S> CompressedSplitWriter<S> {
+    /// Send a message through the connection-scoped writer driver.
+    pub async fn send(&mut self, msg: Message) -> Result<()> {
+        if !self.shared.is_open() {
+            return Err(self.current_error());
         }
-
-        Ok(())
+        let (tx, rx) = oneshot::channel();
+        self.application_tx
+            .send(ApplicationRequest::Send(msg, tx))
+            .await
+            .map_err(|_| self.current_error())?;
+        rx.await.map_err(|_| self.current_error())?
     }
 
     /// Send a text message
@@ -1597,15 +2116,34 @@ where
             .await
     }
 
-    /// Check if the connection is closed
     pub fn is_closed(&self) -> bool {
-        self.closed
+        !self.shared.is_open()
     }
 
-    /// Flush any pending control responses
     pub async fn flush(&mut self) -> Result<()> {
-        self.process_control_requests().await?;
-        self.writer.flush().await.map_err(Into::into)
+        if !self.shared.is_open() {
+            return Err(self.current_error());
+        }
+        let (tx, rx) = oneshot::channel();
+        self.application_tx
+            .send(ApplicationRequest::Flush(tx))
+            .await
+            .map_err(|_| self.current_error())?;
+        rx.await.map_err(|_| self.current_error())?
+    }
+
+    fn current_error(&self) -> Error {
+        self.shared
+            .terminal_tx
+            .borrow()
+            .map_or(Error::ConnectionClosed, TerminalCause::error)
+    }
+}
+
+#[cfg(feature = "permessage-deflate")]
+impl<S> Drop for CompressedSplitWriter<S> {
+    fn drop(&mut self) {
+        self.shared.cancel.cancel();
     }
 }
 
@@ -1615,19 +2153,16 @@ mod tests {
     use futures_util::StreamExt;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-    async fn read_masked_control_frame(
+    async fn read_masked_control_payload(
         io: &mut tokio::io::DuplexStream,
         expected_opcode: u8,
-        expected_payload: &[u8],
-    ) {
+    ) -> Vec<u8> {
         let mut header = [0; 2];
         io.read_exact(&mut header).await.unwrap();
         assert_eq!(header[0], 0x80 | expected_opcode);
         assert_ne!(header[1] & 0x80, 0, "client frames must be masked");
 
         let payload_len = usize::from(header[1] & 0x7f);
-        assert_eq!(payload_len, expected_payload.len());
-
         let mut mask = [0; 4];
         io.read_exact(&mut mask).await.unwrap();
         let mut payload = vec![0; payload_len];
@@ -1635,6 +2170,15 @@ mod tests {
         for (index, byte) in payload.iter_mut().enumerate() {
             *byte ^= mask[index % 4];
         }
+        payload
+    }
+
+    async fn read_masked_control_frame(
+        io: &mut tokio::io::DuplexStream,
+        expected_opcode: u8,
+        expected_payload: &[u8],
+    ) {
+        let payload = read_masked_control_payload(io, expected_opcode).await;
         assert_eq!(payload, expected_payload);
     }
 
@@ -1680,19 +2224,200 @@ mod tests {
         assert!(ws.is_closed());
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn auto_ping_uses_configured_interval_on_read_path() {
         let (client_io, mut server_io) = tokio::io::duplex(1024);
-        let config = Config::builder().auto_ping(true).ping_interval(1).build();
+        let config = Config::builder()
+            .auto_ping(true)
+            .ping_interval(1)
+            .idle_timeout(0)
+            .build();
         let mut ws = WebSocketStream::client(client_io, config);
 
         let read_task = tokio::spawn(async move { ws.next().await });
-        tokio::time::timeout(
-            Duration::from_secs(2),
-            read_masked_control_frame(&mut server_io, 0x09, b""),
-        )
-        .await
-        .expect("automatic Ping was not sent at the configured interval");
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let payload = read_masked_control_payload(&mut server_io, 0x09).await;
+        assert_eq!(payload.len(), 8);
         read_task.abort();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn split_driver_pings_without_application_writes_and_correlates_pong() {
+        let (client_io, mut server_io) = tokio::io::duplex(1024);
+        let config = Config::builder()
+            .ping_interval(1)
+            .pong_timeout(1)
+            .idle_timeout(0)
+            .build();
+        let ws = WebSocketStream::client(client_io, config);
+        let (mut reader, _writer) = ws.split();
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let first_ping = read_masked_control_payload(&mut server_io, 0x09).await;
+        assert_eq!(first_ping.len(), 8);
+
+        let mut pong = vec![0x8a, first_ping.len() as u8];
+        pong.extend_from_slice(&first_ping);
+        server_io.write_all(&pong).await.unwrap();
+        assert!(matches!(
+            reader.next().await,
+            Some(Ok(Message::Pong(payload))) if payload == first_ping
+        ));
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let second_ping = read_masked_control_payload(&mut server_io, 0x09).await;
+        assert_eq!(second_ping.len(), 8);
+        assert_ne!(first_ping, second_ping);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn split_driver_times_out_with_configured_close_and_typed_cause() {
+        let (client_io, mut server_io) = tokio::io::duplex(1024);
+        let config = Config::builder()
+            .ping_interval(1)
+            .pong_timeout(1)
+            .idle_timeout(0)
+            .close_timeout(1)
+            .pong_timeout_close(4201, "Pong reply not received in time")
+            .build();
+        let ws = WebSocketStream::client(client_io, config);
+        let (mut reader, mut writer) = ws.split();
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let _ = read_masked_control_payload(&mut server_io, 0x09).await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let close = read_masked_control_payload(&mut server_io, 0x08).await;
+        assert_eq!(u16::from_be_bytes([close[0], close[1]]), 4201);
+        assert_eq!(&close[2..], b"Pong reply not received in time");
+
+        assert!(matches!(
+            reader.next().await,
+            Some(Err(Error::HeartbeatTimeout))
+        ));
+        assert!(matches!(
+            writer.send_text("too late").await,
+            Err(Error::HeartbeatTimeout)
+        ));
+    }
+
+    #[tokio::test]
+    async fn split_driver_replies_to_peer_ping_without_writer_activity() {
+        let (client_io, mut server_io) = tokio::io::duplex(1024);
+        let config = Config::builder().auto_ping(false).idle_timeout(0).build();
+        let ws = WebSocketStream::client(client_io, config);
+        let (mut reader, _writer) = ws.split();
+
+        server_io
+            .write_all(&[0x89, 0x03, b'p', b'i', b'n'])
+            .await
+            .unwrap();
+        assert!(matches!(
+            reader.next().await,
+            Some(Ok(Message::Ping(payload))) if payload == b"pin"[..]
+        ));
+        read_masked_control_frame(&mut server_io, 0x0a, b"pin").await;
+    }
+
+    #[tokio::test]
+    async fn split_driver_replies_to_peer_close_without_writer_activity() {
+        let (client_io, mut server_io) = tokio::io::duplex(1024);
+        let config = Config::builder().auto_ping(false).idle_timeout(0).build();
+        let ws = WebSocketStream::client(client_io, config);
+        let (mut reader, mut writer) = ws.split();
+
+        server_io
+            .write_all(&[0x88, 0x02, 0x03, 0xe8])
+            .await
+            .unwrap();
+        assert!(matches!(
+            reader.next().await,
+            Some(Ok(Message::Close(Some(reason)))) if reason.code == 1000
+        ));
+        read_masked_control_frame(&mut server_io, 0x08, b"").await;
+        assert!(matches!(
+            writer.send_text("too late").await,
+            Err(Error::ConnectionClosed)
+        ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn split_hard_idle_timeout_is_typed_and_closes_once() {
+        let (client_io, mut server_io) = tokio::io::duplex(1024);
+        let config = Config::builder()
+            .auto_ping(false)
+            .idle_timeout(1)
+            .close_timeout(1)
+            .build();
+        let ws = WebSocketStream::client(client_io, config);
+        let (mut reader, mut writer) = ws.split();
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let close = read_masked_control_payload(&mut server_io, 0x08).await;
+        assert_eq!(
+            u16::from_be_bytes([close[0], close[1]]),
+            CloseReason::GOING_AWAY
+        );
+        assert!(matches!(reader.next().await, Some(Err(Error::IdleTimeout))));
+        assert!(matches!(
+            writer.send_text("after idle").await,
+            Err(Error::IdleTimeout)
+        ));
+        assert!(reader.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn dropping_either_split_half_cancels_the_connection() {
+        let (client_io, _peer_io) = tokio::io::duplex(64);
+        let config = Config::builder().auto_ping(false).idle_timeout(0).build();
+        let (reader, mut writer) = WebSocketStream::client(client_io, config).split();
+        drop(reader);
+        tokio::task::yield_now().await;
+        assert!(matches!(
+            writer.send_text("cancelled").await,
+            Err(Error::ConnectionClosed)
+        ));
+
+        let (client_io, _peer_io) = tokio::io::duplex(64);
+        let config = Config::builder().auto_ping(false).idle_timeout(0).build();
+        let (mut reader, writer) = WebSocketStream::client(client_io, config).split();
+        drop(writer);
+        assert!(reader.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn blocked_split_writer_is_cancelled_when_reader_drops() {
+        let (client_io, _peer_io) = tokio::io::duplex(64);
+        let config = Config::builder().auto_ping(false).idle_timeout(0).build();
+        let (reader, mut writer) = WebSocketStream::client(client_io, config).split();
+        let send = tokio::spawn(async move {
+            writer
+                .send_binary(Bytes::from(vec![0_u8; 1024 * 1024]))
+                .await
+        });
+
+        tokio::task::yield_now().await;
+        drop(reader);
+        assert!(matches!(send.await.unwrap(), Err(Error::ConnectionClosed)));
+    }
+
+    #[cfg(feature = "permessage-deflate")]
+    #[tokio::test(start_paused = true)]
+    async fn compressed_split_driver_sends_uncompressed_native_ping() {
+        let (client_io, mut server_io) = tokio::io::duplex(1024);
+        let config = Config::builder()
+            .ping_interval(1)
+            .pong_timeout(1)
+            .idle_timeout(0)
+            .build();
+        let ws = CompressedWebSocketStream::client(
+            client_io,
+            config,
+            crate::deflate::DeflateConfig::default(),
+        );
+        let (_reader, _writer) = ws.split();
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let payload = read_masked_control_payload(&mut server_io, 0x09).await;
+        assert_eq!(payload.len(), 8);
     }
 }


### PR DESCRIPTION
## Summary

- add a runtime-neutral native WebSocket heartbeat state machine with configurable Ping interval, Pong deadline, hard inbound-idle timeout, close code/reason, and close timeout
- integrate keepalive into Tokio and Compio unified and split transports, including Axum and permessage-deflate paths
- make split transports autonomous through bounded writer-driver queues, cancellation, terminal-state propagation, and reusable encoding buffers
- add typed heartbeat/idle timeout errors, safe close-reason truncation, public configuration builders, documentation, changelog notes, and an updated Axum example

## Why

Connections could previously remain half-open or depend on application writes to make control-frame progress. Native protocol Ping/Pong handling now detects dead peers consistently across supported runtimes and transport modes while preserving automatic Pong and Close behavior.

## Impact

- keepalive behavior is available across Tokio, Compio, Axum, plain, compressed, unified, and split connections
- matching Pong frames clear only their corresponding outstanding Ping; unrelated inbound traffic does not suppress the Pong deadline
- `auto_ping = false` or a zero Ping interval disables proactive Ping, while automatic control replies remain active
- new public `Config` fields and `Error` variants may affect exhaustive struct literals or matches; Tokio split streams now require `Send + 'static`

## Validation

- `cargo fmt --all -- --check`
- `cargo test --no-default-features --features tokio-runtime`
- `cargo test --no-default-features --features "tokio-runtime,permessage-deflate,axum-integration"`
- `cargo test --no-default-features --features compio-runtime`
- `cargo test --no-default-features --features "compio-runtime,permessage-deflate"`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`
